### PR TITLE
Create Github Actions workflows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -59,7 +59,7 @@ jobs:
       id: strings
       shell: bash
       run: |
-        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
     - name: Install Ubuntu build dependencies
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,84 @@
+name: CMake build
+
+on:
+  push:
+    branches: [ "workflows" ]
+  pull_request:
+    branches: [ "workflows" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: false
+
+      # Set up a matrix to run the following 3 configurations:
+      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
+      # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
+      # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
+      # 4. <MacOS, Release, latest Clang compiler toolchain on the default runner image, default generator>
+      #
+      # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        build_type: [Release]
+        c_compiler: [gcc, clang, cl]
+        python-version: ["3.11"]
+        include:
+          - os: windows-latest
+            c_compiler: cl
+            cpp_compiler: cl
+          - os: ubuntu-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: ubuntu-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+          - os: macos-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+        exclude:
+          - os: windows-latest
+            c_compiler: gcc
+          - os: windows-latest
+            c_compiler: clang
+          - os: ubuntu-latest
+            c_compiler: cl
+          - os: macos-latest
+            c_compiler: gcc
+          - os: macos-latest
+            c_compiler: cl
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set reusable strings
+      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Fetch dependencies
+      run: python ./tools/fetch_dawn_dependencies.py
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -S ${{ github.workspace }}
+
+    - name: Build
+      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -80,6 +80,7 @@ jobs:
 
     - name: Set up Visual Studio x64 environment
       if: matrix.os == 'windows-latest'
+      shell: cmd
       run: |
         call "C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvarsall.bat" x64
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,4 +1,4 @@
-name: CMake build
+name: CMake
 
 on:
   push:
@@ -25,7 +25,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         build_type: [Release]
         c_compiler: [gcc, clang, cl]
-        python-version: ["3.11"]
         include:
           - os: windows-latest
             c_compiler: cl
@@ -67,10 +66,10 @@ jobs:
         sudo apt update
         sudo apt install libgl-dev libx11-xcb-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev wayland-protocols libwayland-dev libxkbcommon-dev
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.11
 
     - name: Fetch dependencies
       run: python ./tools/fetch_dawn_dependencies.py --use-test-deps --shallow
@@ -82,7 +81,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       uses: seanmiddleditch/gha-setup-vsdevenv@master
 
-    - name: Setup sccache
+    - name: Set up sccache
       uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Configure CMake

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -60,6 +60,7 @@ jobs:
       shell: bash
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+        echo "build-node-output-dir=${{ github.workspace }}/build-node" >> "$GITHUB_OUTPUT"
 
     - name: Install Ubuntu build dependencies
       if: matrix.os == 'ubuntu-latest'
@@ -102,5 +103,27 @@ jobs:
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+      env:
+        SCCACHE_GHA_ENABLED: "true"
+
+    - name: Configure CMake for dawn.node
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: >
+        cmake -G Ninja -B ${{ steps.strings.outputs.build-node-output-dir }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DCMAKE_C_COMPILER_LAUNCHER=sccache
+        -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+        -DDAWN_BUILD_NODE_BINDINGS=1
+        -DDAWN_ENABLE_PIC=1
+        -S ${{ github.workspace }}
+      env:
+        SCCACHE_GHA_ENABLED: "true"
+
+    - name: Build dawn.node
+      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      run: cmake --build ${{ steps.strings.outputs.build-node-output-dir }} --config ${{ matrix.build_type }} dawn.node
       env:
         SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -59,7 +59,13 @@ jobs:
       id: strings
       shell: bash
       run: |
-        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT
+
+    - name: Install Ubuntu build dependencies
+      if: matrix.os == 'ubuntu-latest
+      run: |
+        sudo apt update
+        sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev wayland-protocols libwayland-dev libxkbcommon-dev
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,7 +79,7 @@ jobs:
       uses: seanmiddleditch/gha-setup-ninja@master
 
     - name: Set up Visual Studio x64 environment
-      if: matrix.is == 'windows-latest'
+      if: matrix.os == 'windows-latest'
       run: |
         call "C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvarsall.bat" x64
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -62,7 +62,7 @@ jobs:
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT
 
     - name: Install Ubuntu build dependencies
-      if: matrix.os == 'ubuntu-latest
+      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt update
         sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev wayland-protocols libwayland-dev libxkbcommon-dev

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -65,7 +65,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt update
-        sudo apt install libgl-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev wayland-protocols libwayland-dev libxkbcommon-dev
+        sudo apt install libgl-dev libx11-xcb-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev wayland-protocols libwayland-dev libxkbcommon-dev
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,23 +15,19 @@ jobs:
       fail-fast: false
 
       # Set up a matrix to run the following 3 configurations:
-      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
-      # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
-      # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
-      # 4. <MacOS, Release, latest Clang compiler toolchain on the default runner image, default generator>
+      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, Ninja>
+      # 2. <Linux, Release, latest Clang compiler toolchain on the default runner image, Ninja>
+      # 3. <MacOS, Release, latest Clang compiler toolchain on the default runner image, Ninja>
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        build_type: [Release]
-        c_compiler: [gcc, clang, cl]
+        build_type: [Debug, Release]
+        c_compiler: [clang, cl]
         include:
           - os: windows-latest
             c_compiler: cl
             cpp_compiler: cl
-          - os: ubuntu-latest
-            c_compiler: gcc
-            cpp_compiler: g++
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
@@ -40,13 +36,9 @@ jobs:
             cpp_compiler: clang++
         exclude:
           - os: windows-latest
-            c_compiler: gcc
-          - os: windows-latest
             c_compiler: clang
           - os: ubuntu-latest
             c_compiler: cl
-          - os: macos-latest
-            c_compiler: gcc
           - os: macos-latest
             c_compiler: cl
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -60,7 +60,6 @@ jobs:
       shell: bash
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
-        echo "build-node-output-dir=${{ github.workspace }}/build-node" >> "$GITHUB_OUTPUT"
 
     - name: Install Ubuntu build dependencies
       if: matrix.os == 'ubuntu-latest'
@@ -103,27 +102,5 @@ jobs:
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
-      env:
-        SCCACHE_GHA_ENABLED: "true"
-
-    - name: Configure CMake for dawn.node
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: >
-        cmake -G Ninja -B ${{ steps.strings.outputs.build-node-output-dir }}
-        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DCMAKE_C_COMPILER_LAUNCHER=sccache
-        -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-        -DDAWN_BUILD_NODE_BINDINGS=1
-        -DDAWN_ENABLE_PIC=1
-        -S ${{ github.workspace }}
-      env:
-        SCCACHE_GHA_ENABLED: "true"
-
-    - name: Build dawn.node
-      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      run: cmake --build ${{ steps.strings.outputs.build-node-output-dir }} --config ${{ matrix.build_type }} dawn.node
       env:
         SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -78,6 +78,11 @@ jobs:
     - name: Set up Ninja
       uses: seanmiddleditch/gha-setup-ninja@master
 
+    - name: Set up Visual Studio x64 environment
+      if: matrix.is == 'windows-latest'
+      run: |
+        call "C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvarsall.bat" x64
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,3 +1,4 @@
+# Workflow to build Dawn using CMake
 name: CMake
 
 on:
@@ -5,6 +6,10 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -78,11 +78,9 @@ jobs:
     - name: Set up Ninja
       uses: seanmiddleditch/gha-setup-ninja@master
 
-    - name: Set up Visual Studio x64 environment
+    - name: Set up Visual Studio environment
       if: matrix.os == 'windows-latest'
-      shell: cmd
-      run: |
-        call "C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvarsall.bat" x64
+      uses: seanmiddleditch/gha-setup-vsdevenv@master
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -75,11 +75,14 @@ jobs:
     - name: Fetch dependencies
       run: python ./tools/fetch_dawn_dependencies.py --use-test-deps --shallow
 
+    - name: Set up Ninja
+      uses: seanmiddleditch/gha-setup-ninja@master
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
-        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        cmake -G Ninja -B ${{ steps.strings.outputs.build-output-dir }}
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -67,7 +67,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Fetch dependencies
-      run: python ./tools/fetch_dawn_dependencies.py
+      run: python ./tools/fetch_dawn_dependencies.py --use-test-deps --shallow
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,6 +37,9 @@ jobs:
         exclude:
           - os: windows-latest
             c_compiler: clang
+          - os: windows-latest
+            c_compiler: cl
+            build_type: Debug
           - os: ubuntu-latest
             c_compiler: cl
           - os: macos-latest

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -65,7 +65,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt update
-        sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev wayland-protocols libwayland-dev libxkbcommon-dev
+        sudo apt install libgl-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev wayland-protocols libwayland-dev libxkbcommon-dev
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,9 @@ name: CMake
 
 on:
   push:
-    branches: [ "workflows" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "workflows" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -82,6 +82,9 @@ jobs:
       if: matrix.os == 'windows-latest'
       uses: seanmiddleditch/gha-setup-vsdevenv@master
 
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
@@ -90,8 +93,14 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DCMAKE_C_COMPILER_LAUNCHER=sccache
+        -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
         -S ${{ github.workspace }}
+      env:
+        SCCACHE_GHA_ENABLED: "true"
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+      env:
+        SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/gn.yml
+++ b/.github/workflows/gn.yml
@@ -23,13 +23,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - name: Set reusable strings
-      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
-      id: strings
-      shell: bash
-      run: |
-        echo "gclient-cache-dir=${RUNNER_TEMP}/.gclient_cache" >> "$GITHUB_OUTPUT"
-
     - name: Install Ubuntu build dependencies
       if: matrix.os == 'ubuntu-latest'
       run: |
@@ -44,29 +37,11 @@ jobs:
     - name: Set up checkout
       run: |
         cp ./scripts/standalone.gclient .gclient
-        mkdir -p ${{ steps.strings.outputs.gclient-cache-dir }}
-
-    - name: gclient restore cache
-      id: gclient-restore
-      uses: actions/cache/restore@v3
-      with:
-        path: ${{ steps.strings.outputs.gclient-cache-dir }}
-        key: ${{ runner.os }}-${{ hashFiles('DEPS') }}
-        restore-keys: ${{ runner.os }}-
 
     - name: gclient sync --no-history --shallow
       run: gclient sync --no-history --shallow
       env:
-        GIT_CACHE_PATH: ${{ steps.strings.outputs.gclient-cache-dir }}
         DEPOT_TOOLS_WIN_TOOLCHAIN: 0
-
-    - name: gclient save cache
-      id: gclient-save
-      uses: actions/cache/save@v3
-      if: steps.gclient-save.outputs.cache-hit != 'true'
-      with:
-        path: ${{ steps.strings.outputs.gclient-cache-dir }}
-        key: ${{ steps.gclient-restore.outputs.cache-primary-key }}
 
     - name: Set up sccache
       uses: mozilla-actions/sccache-action@v0.0.3
@@ -75,11 +50,12 @@ jobs:
       shell: bash
       run: |
         mkdir -p out/build
-        touch out/build/args.gn
-        echo "cc_wrapper=\"sccache\"" >> out/build/args.gn
-        echo "is_debug=true" >> out/build/args.gn
-        echo "is_component_build=true" >> out/build/args.gn
-        echo "is_clang=true" >> out/build/args.gn
+        cat << EOF >> out/build/args.gn
+        cc_wrapper="sccache"
+        is_debug=false
+        is_component_build=true
+        is_clang=true
+        EOF
         gn gen out/build
 
       env:

--- a/.github/workflows/gn.yml
+++ b/.github/workflows/gn.yml
@@ -1,0 +1,93 @@
+# Workflow to build Dawn using GN
+name: GN
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: false
+
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - name: Set reusable strings
+      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
+      id: strings
+      shell: bash
+      run: |
+        echo "gclient-cache-dir=${RUNNER_TEMP}/.gclient_cache" >> "$GITHUB_OUTPUT"
+
+    - name: Install Ubuntu build dependencies
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt update
+        sudo apt install libgl-dev libx11-xcb-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev wayland-protocols libwayland-dev libxkbcommon-dev
+
+    - name: Install depot_tools
+      uses: newkdev/setup-depot-tools@v1.0.1
+
+    - uses: actions/checkout@v3
+
+    - name: Set up checkout
+      run: |
+        cp ./scripts/standalone.gclient .gclient
+        mkdir -p ${{ steps.strings.outputs.gclient-cache-dir }}
+
+    - name: gclient restore cache
+      id: gclient-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: ${{ steps.strings.outputs.gclient-cache-dir }}
+        key: ${{ runner.os }}-${{ hashFiles('DEPS') }}
+        restore-keys: ${{ runner.os }}-
+
+    - name: gclient sync --no-history --shallow
+      run: gclient sync --no-history --shallow
+      env:
+        GIT_CACHE_PATH: ${{ steps.strings.outputs.gclient-cache-dir }}
+        DEPOT_TOOLS_WIN_TOOLCHAIN: 0
+
+    - name: gclient save cache
+      id: gclient-save
+      uses: actions/cache/save@v3
+      if: steps.gclient-save.outputs.cache-hit != 'true'
+      with:
+        path: ${{ steps.strings.outputs.gclient-cache-dir }}
+        key: ${{ steps.gclient-restore.outputs.cache-primary-key }}
+
+    - name: Set up sccache
+      uses: mozilla-actions/sccache-action@v0.0.3
+
+    - name: Generate build files
+      shell: bash
+      run: |
+        mkdir -p out/build
+        touch out/build/args.gn
+        echo "cc_wrapper=\"sccache\"" >> out/build/args.gn
+        echo "is_debug=true" >> out/build/args.gn
+        echo "is_component_build=true" >> out/build/args.gn
+        echo "is_clang=true" >> out/build/args.gn
+        gn gen out/build
+
+      env:
+        SCCACHE_GHA_ENABLED: "true"
+        DEPOT_TOOLS_WIN_TOOLCHAIN: 0
+
+    - name: Build
+      run: autoninja -C out/build
+      env:
+        SCCACHE_GHA_ENABLED: "true"
+        DEPOT_TOOLS_WIN_TOOLCHAIN: 0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,28 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "workflows" ]
+  pull_request:
+    branches: [ "workflows" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.18'
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,9 +5,9 @@ name: Go
 
 on:
   push:
-    branches: [ "workflows" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "workflows" ]
+    branches: [ "main" ]
 
 jobs:
 


### PR DESCRIPTION
Add initial Github workflows to:
 - Build and run go tests
 - Do the cmake build on Windows/Linux/MacOS
 - CMake build with GCC is skipped for now due to compiler-specific failures
 - Debug CMake build with MSVC is skipped for now due to issues with PDB file locking and multiple compile threads
 - GN build for convenience of getting build results in Github PRs; may or may not keep it long term