### PR TITLE
Add Github workflow on copybara import

### DIFF
--- a/.github/workflows/on-copybara-import.yml
+++ b/.github/workflows/on-copybara-import.yml
@@ -2,6 +2,8 @@ name: On copybara import
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [ "main" ]
   check_run:
     types:
       - completed

--- a/.github/workflows/on-copybara-import.yml
+++ b/.github/workflows/on-copybara-import.yml
@@ -3,7 +3,8 @@ name: On copybara import
 on:
   workflow_dispatch:
   check_run:
-    type: ['completed']
+    types:
+      - completed
 
 jobs:
   comment:

--- a/.github/workflows/on-copybara-import.yml
+++ b/.github/workflows/on-copybara-import.yml
@@ -1,6 +1,7 @@
 name: On copybara import
 
 on:
+  workflow_dispatch:
   check_run:
     type: ['completed']
 

--- a/.github/workflows/on-copybara-import.yml
+++ b/.github/workflows/on-copybara-import.yml
@@ -8,13 +8,55 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  comment:
-    name: Comment after successful copybara import
-    if: github.event.check_run.name == 'import/copybara' && github.event.check_run.conclusion == 'success'
+  comment_test:
+    name: comment test
+    if: github.event.pull_request.number
     runs-on: ubuntu-latest
     steps:
-    - name: Comment on PR
-      shell: bash
-      run: |
-        echo "${{ github.event.check_run.details_url }}"
+    - name: Wait for import/copybara
+      uses: lewagon/wait-on-check-action@v1.3.1
+      with:
+        ref: ${{ github.ref }}
+        check-name: 'import/copybara'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        wait-interval: 10
+    - uses: actions/github-script@v6
+      name: Comment on PR
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: github.event.pull_request.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: |
+              👋 Thanks for your contribution! Your PR has been imported to Gerrit.
+              Please visit Gerrit to see it and CC yourself on the change.
+              All comments are handled within Gerrit. Any comments on the GitHub PR may be ignored.
+              You can continue to upload commits to the PR in order to address feedback from Gerrit.
+          })
+
+  comment:
+    name: comment
+    if: github.event.check_run.name == 'import/copybara' && github.event.check_run.conclusion == 'success' && github.event.check_run.pull_requests[0]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v6
+      name: Comment on PR
+      with:
+        script: |
+          console.log(github.event.check_run)
+          github.rest.issues.createComment({
+            issue_number: github.event.check_run.pull_requests[0].number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: |
+              👋 Thanks for your contribution! Your PR has been imported to Gerrit.
+              Please visit ${{ github.event.check_run.details_url }} to see it and CC yourself on the change.
+              All comments are handled within Gerrit. Any comments on the GitHub PR may be ignored.
+              You can continue to upload commits to the PR in order to address feedback from Gerrit.
+          })

--- a/.github/workflows/on-copybara-import.yml
+++ b/.github/workflows/on-copybara-import.yml
@@ -4,8 +4,18 @@ on:
   check_run:
     types:
       - completed
+  status:
 
 jobs:
+  log_event:
+    name: log event
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v6
+      name: Log Event
+      with:
+        script: console.log(github.event)
+
   comment:
     name: comment
     if: github.event.check_run.name == 'import/copybara' && github.event.check_run.conclusion == 'success' && github.event.check_run.pull_requests[0]

--- a/.github/workflows/on-copybara-import.yml
+++ b/.github/workflows/on-copybara-import.yml
@@ -4,6 +4,13 @@ on:
   status
 
 jobs:
+  debug:
+    name: debug
+    runs-on: ubuntu-latest
+    steps:
+      name: Dump Github Context
+      run: echo '${{ toJSON(github) }}'
+
   comment:
     name: comment
     if: github.event.state == 'success' && github.event.context == 'import/copybara'

--- a/.github/workflows/on-copybara-import.yml
+++ b/.github/workflows/on-copybara-import.yml
@@ -1,10 +1,12 @@
 name: On copybara import
 
 on:
-  workflow_dispatch:
   pull_request:
     branches: [ "main" ]
   check_run:
+    types:
+      - completed
+  check_suite:
     types:
       - completed
 
@@ -13,32 +15,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  comment_test:
-    name: comment test
-    if: github.event.pull_request.number
+  comment2:
+    name: comment2
     runs-on: ubuntu-latest
     steps:
-    - name: Wait for import/copybara
-      uses: lewagon/wait-on-check-action@v1.3.1
-      with:
-        ref: ${{ github.ref }}
-        check-name: 'import/copybara'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        wait-interval: 10
     - uses: actions/github-script@v6
-      name: Comment on PR
+      name: Test check_suite event
       with:
         script: |
-          github.rest.issues.createComment({
-            issue_number: github.event.pull_request.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: |
-              👋 Thanks for your contribution! Your PR has been imported to Gerrit.
-              Please visit Gerrit to see it and CC yourself on the change.
-              All comments are handled within Gerrit. Any comments on the GitHub PR may be ignored.
-              You can continue to upload commits to the PR in order to address feedback from Gerrit.
-          })
+          console.log(github.event.check_suite)
 
   comment:
     name: comment

--- a/.github/workflows/on-copybara-import.yml
+++ b/.github/workflows/on-copybara-import.yml
@@ -9,8 +9,22 @@ jobs:
     if: github.event.state == 'success' && github.event.context == 'import/copybara'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/github-script@v6
-      name: Comment on PR
+
+    - name: Find PR
+      uses: sharesight/find-github-pull-request@1.2.0
       with:
-        script: |
-          console.log(github.event)
+        commitSha: ${{ github.event.sha }}
+        allowClosed: false
+        failIfNotFound: false
+
+    - name: Comment on PR
+      if: steps.find-pr.outputs.number != ''
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        number: ${{ steps.find-pr.outputs.number }}
+        header: pr_was_imported # key to reuse the same comment
+        message: |
+          👋 Thanks for your contribution! Your PR has been imported to Gerrit.
+          Please visit ${{ github.event.target_url }} to see it and CC yourself on the change.
+          All comments are handled within Gerrit. Any comments on the GitHub PR may be ignored.
+          You can continue to upload commits to the PR in order to address feedback from Gerrit.

--- a/.github/workflows/on-copybara-import.yml
+++ b/.github/workflows/on-copybara-import.yml
@@ -1,38 +1,16 @@
 name: On copybara import
 
 on:
-  check_run:
-    types:
-      - completed
-  status:
+  status
 
 jobs:
-  log_event:
-    name: log event
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/github-script@v6
-      name: Log Event
-      with:
-        script: console.log(github.event)
-
   comment:
     name: comment
-    if: github.event.check_run.name == 'import/copybara' && github.event.check_run.conclusion == 'success' && github.event.check_run.pull_requests[0]
+    if: github.event.state == 'success' && github.event.context == 'import/copybara'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/github-script@v6
       name: Comment on PR
       with:
         script: |
-          console.log(github.event.check_run)
-          github.rest.issues.createComment({
-            issue_number: github.event.check_run.pull_requests[0].number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: |
-              👋 Thanks for your contribution! Your PR has been imported to Gerrit.
-              Please visit ${{ github.event.check_run.details_url }} to see it and CC yourself on the change.
-              All comments are handled within Gerrit. Any comments on the GitHub PR may be ignored.
-              You can continue to upload commits to the PR in order to address feedback from Gerrit.
-          })
+          console.log(github.event)

--- a/.github/workflows/on-copybara-import.yml
+++ b/.github/workflows/on-copybara-import.yml
@@ -1,0 +1,16 @@
+name: On copybara import
+
+on:
+  check_run:
+    type: ['completed']
+
+jobs:
+  comment:
+    name: Comment after successful copybara import
+    if: github.event.check_run.name == 'import/copybara' && github.event.check_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Comment on PR
+      shell: bash
+      run: |
+        echo "${{ github.event.check_run.details_url }}"

--- a/.github/workflows/on-copybara-import.yml
+++ b/.github/workflows/on-copybara-import.yml
@@ -1,30 +1,11 @@
 name: On copybara import
 
 on:
-  pull_request:
-    branches: [ "main" ]
   check_run:
     types:
       - completed
-  check_suite:
-    types:
-      - completed
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
-  comment2:
-    name: comment2
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/github-script@v6
-      name: Test check_suite event
-      with:
-        script: |
-          console.log(github.event.check_suite)
-
   comment:
     name: comment
     if: github.event.check_run.name == 'import/copybara' && github.event.check_run.conclusion == 'success' && github.event.check_run.pull_requests[0]


### PR DESCRIPTION
When the import/copybara status check succeeds, post a comment on the PR directing developers to see the imported CL on Gerrit.

Unfortunately, it is not possible to test this workflow until it lands, so a debugging job is included as well which will be removed in the future.