### PR TITLE
Update README.md and change CI concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,10 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Use github.run_id on main branch
+  # Use github.event.pull_request.number on pull requests, so it's unique per pull request
+  # Use github.ref on other branches, so it's unique per branch
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-<img
-  title="Dawn's logo"
-  alt="Dawn's logo: a sun rising behind a stylized mountain inspired by the WebGPU logo."
-  src="docs/imgs/dawn_logo_notext.png"
-  style="display:block; width:50%; margin-left: auto; margin-right: auto">
+<div align="center">
+  <img
+      title="Dawn's logo"
+      alt="Dawn's logo: a sun rising behind a stylized mountain inspired by the WebGPU logo."
+      src="docs/imgs/dawn_logo_notext.png"
+      width="50%">
 
-![Build Status](https://github.com/google/dawn/actions/workflows/ci.yml/badge.svg?branch=main&event=push)
-[![Matrix Space](https://img.shields.io/static/v1?label=Space&message=%23webgpu-dawn&color=blue&logo=matrix)](https://matrix.to/#/#webgpu-dawn:matrix.org)
+  ![Build Status](https://github.com/google/dawn/actions/workflows/ci.yml/badge.svg?branch=main&event=push)
+  [![Matrix Space](https://img.shields.io/static/v1?label=Space&message=%23webgpu-dawn&color=blue&logo=matrix)](https://matrix.to/#/#webgpu-dawn:matrix.org)
+</div>
 
 # Dawn, a WebGPU implementation
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-![Dawn's logo: a sun rising behind a stylized mountain inspired by the WebGPU logo. The text "Dawn" is written below it.](docs/imgs/dawn_logo.png "Dawn's logo")
+<img
+  title="Dawn's logo"
+  alt="Dawn's logo: a sun rising behind a stylized mountain inspired by the WebGPU logo."
+  src="docs/imgs/dawn_logo_notext.png"
+  style="display:block; width:50%; margin-left: auto; margin-right: auto">
+
+![Build Status](https://github.com/google/dawn/actions/workflows/ci.yml/badge.svg?branch=main&event=push)
+[![Matrix Space](https://img.shields.io/static/v1?label=Space&message=%23webgpu-dawn&color=blue&logo=matrix)](https://matrix.to/#/#webgpu-dawn:matrix.org)
 
 # Dawn, a WebGPU implementation
 
-Dawn is an open-source and cross-platform implementation of the work-in-progress [WebGPU](https://webgpu.dev) standard.
+Dawn is an open-source and cross-platform implementation of the [WebGPU](https://webgpu.dev) standard.
 More precisely it implements [`webgpu.h`](https://github.com/webgpu-native/webgpu-headers/blob/main/webgpu.h) that is a one-to-one mapping with the WebGPU IDL.
 Dawn is meant to be integrated as part of a larger system and is the underlying implementation of WebGPU in Chromium.
 
@@ -41,10 +48,6 @@ Developer documentation:
 
 
 User documentation: (TODO, figure out what overlaps with the webgpu.h docs)
-
-## Status
-
-(TODO)
 
 ## License
 


### PR DESCRIPTION
- Add CI build status
- Use different concurrency id for the main branch - so we don't cancel builds for pushes to `main`
- Add matrix space badge
- Format logo to be centered and only 50% width
- Use notext logo since "Dawn" is already written below in the Markdown title. No text also displays better in dark mode UI.