### PR TITLE
Disable Alt-Enter tracking by DXGI on HWND window

### DIFF
--- a/src/dawn/native/d3d/SwapChainD3D.cpp
+++ b/src/dawn/native/d3d/SwapChainD3D.cpp
@@ -211,6 +211,11 @@ MaybeError SwapChain::InitializeSwapChainFromScratch() {
                                                  static_cast<HWND>(GetSurface()->GetHWND()),
                                                  &swapChainDesc, nullptr, nullptr, &swapChain1),
                 "Creating the IDXGISwapChain1"));
+
+            const HRESULT mwaResult = factory2->MakeWindowAssociation(static_cast<HWND>(GetSurface()->GetHWND()), DXGI_MWA_NO_ALT_ENTER);
+            if (mwaResult != DXGI_ERROR_NOT_CURRENTLY_AVAILABLE) {
+                DAWN_TRY(CheckHRESULT(mwaResult, "MakeWindowAssociation"));
+            }
             break;
         }
         case Surface::Type::WindowsCoreWindow: {


### PR DESCRIPTION
This change is motivated by letting user handle window and video mode changes by himself and it also addresses freeze / D3D device loss happening after pressing Alt-Enter. Other backends like Vulkan do not change video mode with Alt-Enter anyway.