### PR TITLE
Add googletest to python deps script

### DIFF
--- a/tools/fetch_dawn_dependencies.py
+++ b/tools/fetch_dawn_dependencies.py
@@ -88,7 +88,7 @@ parser.add_argument('-t',
                     action='store_true',
                     default=False,
                     help="""
-    Fetch dependencies needed for testing
+    Deprecated: Test dependencies are now always included.
     """)
 
 
@@ -108,17 +108,13 @@ def main(args):
         'third_party/markupsafe',
         'third_party/glslang/src',
         'third_party/google_benchmark/src',
+        'third_party/googletest',
         'third_party/spirv-headers/src',
         'third_party/spirv-tools/src',
         'third_party/vulkan-headers/src',
         'third_party/vulkan-loader/src',
         'third_party/vulkan-utility-libraries/src',
     ]
-
-    if args.use_test_deps:
-        required_submodules += [
-            'third_party/googletest',
-        ]
 
     root_dir = Path(args.directory).resolve()
 

--- a/tools/fetch_dawn_dependencies.py
+++ b/tools/fetch_dawn_dependencies.py
@@ -115,6 +115,8 @@ def main(args):
         'third_party/vulkan-loader/src',
         'third_party/vulkan-utility-libraries/src',
     ]
+    if args.use_test_deps:
+        log("WARNING: --use-test-deps argument deprecated. Test dependencies are now always included.")
 
     root_dir = Path(args.directory).resolve()
 

--- a/tools/fetch_dawn_dependencies.py
+++ b/tools/fetch_dawn_dependencies.py
@@ -116,7 +116,8 @@ def main(args):
         'third_party/vulkan-utility-libraries/src',
     ]
     if args.use_test_deps:
-        log("WARNING: --use-test-deps argument deprecated. Test dependencies are now always included.")
+        log("""WARNING: --use-test-deps argument deprecated. 
+            Test dependencies are now always included.""")
 
     root_dir = Path(args.directory).resolve()
 


### PR DESCRIPTION
Without this dependency, automated builds will error since the third_party/googletest folder does not have a CMakeLists.txt or is required somewhere and should not be.