### PR TITLE
include <cstddef>

### DIFF
--- a/src/dawn/common/Sha3.h
+++ b/src/dawn/common/Sha3.h
@@ -29,6 +29,7 @@
 #define SRC_DAWN_COMMON_SHA3_H_
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 
 namespace dawn {


### PR DESCRIPTION
This fixes compilation on systems that do not infer size_t. My Linux build broke today after inclusion of the SHA3 addition.

Apologies for the reopen/duplicate, had a bunch of submodule changes in the merge.
