### PR TITLE
Move Abseil add_subdirectory to third_party

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,9 +443,6 @@ if (DAWN_BUILD_PROTOBUF AND EXISTS "${DAWN_PROTOBUF_DIR}/cmake")
   if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") AND WIN32)
     set(protobuf_HAVE_BUILTIN_ATOMICS 1)
   endif()
-
-  # Needs to come before SPIR-V Tools
-  include("third_party/protobuf.cmake")
 endif()
 
 add_subdirectory(third_party)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,28 +439,6 @@ set(TINT_SPIRV_TOOLS_DIR   ${DAWN_SPIRV_TOOLS_DIR})
 ################################################################################
 # Run on all subdirectories
 ################################################################################
-# Needed by protobuf and other dependencies in third_party
-set(ABSL_ROOT_DIR ${DAWN_ABSEIL_DIR})
-if (NOT TARGET absl::strings)
-    # Recommended setting for compatibility with future abseil releases.
-    set(ABSL_PROPAGATE_CXX_STD ON CACHE BOOL "" FORCE)
-    message(STATUS "Dawn: using Abseil at ${DAWN_ABSEIL_DIR}")
-    if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR
-        ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang"))
-        add_compile_options(
-            -Wno-array-parameter
-            -Wno-deprecated-builtins
-            -Wno-unknown-warning-option
-            -Wno-gcc-compat
-            -Wno-unreachable-code-break
-            -Wno-nullability-extension
-            -Wno-shadow
-        )
-    endif()
-
-    add_subdirectory(${DAWN_ABSEIL_DIR} "${CMAKE_CURRENT_BINARY_DIR}/abseil")
-endif()
-
 if (DAWN_BUILD_PROTOBUF AND EXISTS "${DAWN_PROTOBUF_DIR}/cmake")
   if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") AND WIN32)
     set(protobuf_HAVE_BUILTIN_ATOMICS 1)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -90,6 +90,11 @@ if (NOT TARGET absl::strings)
     add_subdirectory(${DAWN_ABSEIL_DIR} "${CMAKE_CURRENT_BINARY_DIR}/abseil")
 endif()
 
+if (DAWN_BUILD_PROTOBUF AND EXISTS "${DAWN_PROTOBUF_DIR}/cmake")
+  # Needs to come before SPIR-V Tools
+  include("third_party/protobuf.cmake")
+endif()
+
 ################################################################################
 # End of Emscripten enabled third party directories
 ################################################################################

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -69,6 +69,27 @@ if ((DAWN_BUILD_TESTS OR TINT_BUILD_TESTS) AND NOT TARGET gmock)
     add_subdirectory(${DAWN_GOOGLETEST_DIR} "${CMAKE_CURRENT_BINARY_DIR}/googletest" EXCLUDE_FROM_ALL)
 endif()
 
+set(ABSL_ROOT_DIR ${DAWN_ABSEIL_DIR})
+if (NOT TARGET absl::strings)
+    # Recommended setting for compatibility with future abseil releases.
+    set(ABSL_PROPAGATE_CXX_STD ON CACHE BOOL "" FORCE)
+    message(STATUS "Dawn: using Abseil at ${DAWN_ABSEIL_DIR}")
+    if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR
+        ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang"))
+        add_compile_options(
+            -Wno-array-parameter
+            -Wno-deprecated-builtins
+            -Wno-unknown-warning-option
+            -Wno-gcc-compat
+            -Wno-unreachable-code-break
+            -Wno-nullability-extension
+            -Wno-shadow
+        )
+    endif()
+
+    add_subdirectory(${DAWN_ABSEIL_DIR} "${CMAKE_CURRENT_BINARY_DIR}/abseil")
+endif()
+
 ################################################################################
 # End of Emscripten enabled third party directories
 ################################################################################


### PR DESCRIPTION
Handling Abseil in the root CMake is inconsistent with other dependencies, which are all handled in `third_party/CMakeLists.txt`. Moreover, it breaks the `DAWN_FETCH_DEPENDENCIES` mechanism since it tries to add Abseil before it was fetched (hence breaking the GitHub CI).

Issue was introduced by f7c65dd9e72861d3bf9f327aa6fbb774eeeb8746