### PR TITLE
DXD12:  Fix Compilation error

### DIFF
--- a/src/dawn/native/d3d12/CommandBufferD3D12.cpp
+++ b/src/dawn/native/d3d12/CommandBufferD3D12.cpp
@@ -1195,7 +1195,7 @@ MaybeError CommandBuffer::RecordCommands(CommandRecordingContext* commandContext
                                                               wgpu::BufferUsage::CopyDst);
                         commandList->CopyBufferRegion(
                             dstBuffer->GetD3D12Resource(), offset,
-                            ToBackend(reservation.buffer)->GetD3D12Resource(),
+                            ToBackend(reservation.buffer.Get())->GetD3D12Resource(),
                             reservation.offsetInBuffer, size);
                         return {};
                     }));
@@ -1256,7 +1256,7 @@ MaybeError CommandBuffer::RecordComputePass(CommandRecordingContext* commandCont
                 ComPtr<ID3D12CommandSignature> signature =
                     lastPipeline->GetDispatchIndirectCommandSignature();
                 commandList->ExecuteIndirect(
-                    signature.Get(), 1, ToBackend(dispatch->indirectBuffer)->GetD3D12Resource(),
+                    signature.Get(), 1, ToBackend(dispatch->indirectBuffer.Get())->GetD3D12Resource(),
                     dispatch->indirectOffset, nullptr, 0);
                 currentDispatch++;
                 break;
@@ -1277,7 +1277,7 @@ MaybeError CommandBuffer::RecordComputePass(CommandRecordingContext* commandCont
 
             case Command::SetComputePipeline: {
                 SetComputePipelineCmd* cmd = mCommands.NextCommand<SetComputePipelineCmd>();
-                ComputePipeline* pipeline = ToBackend(cmd->pipeline).Get();
+                ComputePipeline* pipeline = ToBackend(cmd->pipeline.Get());
 
                 commandList->SetPipelineState(pipeline->GetPipelineState());
 
@@ -1719,7 +1719,7 @@ MaybeError CommandBuffer::RecordRenderPass(CommandRecordingContext* commandConte
 
             case Command::SetRenderPipeline: {
                 SetRenderPipelineCmd* cmd = iter->NextCommand<SetRenderPipelineCmd>();
-                RenderPipeline* pipeline = ToBackend(cmd->pipeline).Get();
+                RenderPipeline* pipeline = ToBackend(cmd->pipeline.Get());
 
                 commandList->SetPipelineState(pipeline->GetPipelineState());
                 commandList->IASetPrimitiveTopology(pipeline->GetD3D12PrimitiveTopology());
@@ -1749,7 +1749,7 @@ MaybeError CommandBuffer::RecordRenderPass(CommandRecordingContext* commandConte
 
                 D3D12_INDEX_BUFFER_VIEW bufferView;
                 bufferView.Format = DXGIIndexFormat(cmd->format);
-                bufferView.BufferLocation = ToBackend(cmd->buffer)->GetVA() + cmd->offset;
+                bufferView.BufferLocation = ToBackend(cmd->buffer.Get())->GetVA() + cmd->offset;
                 bufferView.SizeInBytes = cmd->size;
 
                 commandList->IASetIndexBuffer(&bufferView);

--- a/src/tint/lang/spirv/writer/raise/shader_io.cc
+++ b/src/tint/lang/spirv/writer/raise/shader_io.cc
@@ -99,7 +99,7 @@ struct StateImpl : core::ir::transform::ShaderIOBackendState {
                 // Vulkan requires that fragment integer builtin inputs be Flat decorated.
                 if (func->IsFragment() && addrspace == core::AddressSpace::kIn &&
                     io.type->IsIntegerScalarOrVector()) {
-                    io.attributes.interpolation = {core::InterpolationType::kFlat};
+                    io.attributes.interpolation = core::Interpolation{core::InterpolationType::kFlat};
                 }
             }
             if (io.attributes.location) {


### PR DESCRIPTION
I hadn't updated Dawn since 2024. When I updated to the latest version, it failed to compile.

![FailCompile1](https://github.com/user-attachments/assets/7a8ab293-f676-4fa8-a1a4-bf1247441f71)

![FailCompile2](https://github.com/user-attachments/assets/c20e3de6-5469-4ef2-86d7-581348d266c4)

I've since fixed it, and it now compiles successfully.

### what is the problem?

I checked the history of files __src/tint/lang/spirv/writer/raise/shader_io.cc__

I noticed that the line 

```cpp
io.attributes.interpolation = {core::InterpolationType::kFlat};
```
hadn't changed since 2024. Despite this, this code worked in the previous version but suddenly caused compilation errors after the update.


I also checked the history for __src/dawn/native/d3d12/CommandBufferD3D12.cpp__ 

and confirmed that the code I needed to change to apply the fix had also not been modified since 2024.

Given that the relevant code itself hadn't changed, I suspect the compilation error was likely due to something in my environment.


