### PR TITLE
[tint] Fix build break on GCC 12

### DIFF
--- a/src/dawn/native/ShaderModule.h
+++ b/src/dawn/native/ShaderModule.h
@@ -205,7 +205,7 @@ enum class TextureQueryType : uint8_t { TextureNumLevels, TextureNumSamples };
     X(uint32_t, group)                   \
     X(uint32_t, binding)
 DAWN_SERIALIZABLE(struct, TextureMetadataQuery, TEXTURE_METADATE_QUERY_MEMBER) {
-    using TextureQueryType = TextureQueryType;
+    using TextureQueryType = detail::TextureQueryType;
 };
 #undef TEXTURE_METADATE_QUERY_MEMBER
 


### PR DESCRIPTION
Fix the following build break on GCC 12:

```
/build/Release/_deps/dawn-src/src/dawn/native/ShaderModule.h:208:11: error: declaration of ‘using TextureQueryType = enum class dawn::native::detail::TextureQueryType’ changes meaning of ‘TextureQueryType’ [-fpermissive]
  208 |     using TextureQueryType = TextureQueryType;
      |           ^~~~~~~~~~~~~~~~
/build/Release/_deps/dawn-src/src/dawn/native/ShaderModule.h:201:12: note: ‘TextureQueryType’ declared here as ‘enum class dawn::native::detail::TextureQueryType’
  201 | enum class TextureQueryType : uint8_t { TextureNumLevels, TextureNumSamples };
      |            ^~~~~~~~~~~~~~~~
```