### PR TITLE
Fix include `dxcapi.h`

### DIFF
--- a/src/tint/lang/hlsl/validate/validate.cc
+++ b/src/tint/lang/hlsl/validate/validate.cc
@@ -50,7 +50,7 @@ TINT_BEGIN_DISABLE_ALL_WARNINGS();
 // # Use UUID emulation with clang to avoid compiling with ms-extensions
 #define __EMULATE_UUID
 #endif
-#include "dxc/dxcapi.h"
+#include <dxcapi.h>
 TINT_END_DISABLE_ALL_WARNINGS();
 
 // Disable warnings about old-style casts which result from using


### PR DESCRIPTION
Hello, I am currently doing a port of Dawn on vcpkg. During this I had to fix an include of `dxcapi.h`, the code in **tint** prefixes that filename... As a result, the compiler cannot find `dxcapi.h` when provided by vcpkg. Sorry for this 6-characters PR.

Almost unrelated, but still about header inclusion, it seems **tint** includes private headers from SPIRV-Tools (namely [`source/opt_ir_context.h`](https://github.com/KhronosGroup/SPIRV-Tools/blob/main/source/opt/ir_context.h)), is that really necessary ? If so, is there a way to bring that back to upstream ?