### PR TITLE
Fix missing <cstdint> include in TypedInteger.h

### DIFF
--- a/src/dawn/common/TypedInteger.h
+++ b/src/dawn/common/TypedInteger.h
@@ -30,6 +30,7 @@
 
 #include <compare>
 #include <concepts>
+#include <cstdint>
 #include <limits>
 #include <ostream>
 #include <type_traits>


### PR DESCRIPTION
I wasn't able to build Dawn on Ubuntu 25.04 w/ GCC 14.2.0 because of the following error:
```
In file included from /tmp/dawn-20250829.192131/src/dawn/common/ityp_array.h:36,
                 from /tmp/dawn-20250829.192131/out/Debug/gen/src/dawn/native/ObjectType_autogen.h:5,
                 from /tmp/dawn-20250829.192131/out/Debug/gen/src/dawn/native/ObjectType_autogen.cpp:2:
/tmp/dawn-20250829.192131/src/dawn/common/TypedInteger.h: In constructor ‘constexpr dawn::detail::TypedIntegerImpl<Tag, T>::TypedIntegerImpl(I)’:
/tmp/dawn-20250829.192131/src/dawn/common/TypedInteger.h:103:35: error: ‘uint64_t’ does not name a type
  103 |         static_assert(static_cast<uint64_t>(std::numeric_limits<I>::max()) <=
      |                                   ^~~~~~~~
/tmp/dawn-20250829.192131/src/dawn/common/TypedInteger.h:40:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
```

Adding the missing include fixes the issue.