### PR TITLE
Only strip debug symbols on Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
           ninja -C ${{ matrix.output_dir }}
 
-      - name: Strip debug symbols Android binaries
+      - name: Strip debug symbols
         run: |
           ${{ matrix.strip_tool }} --strip-debug ${{ matrix.output_dir }}/${{ matrix.library_path }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,9 +194,9 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
           ninja -C ${{ matrix.output_dir }}
 
-      - name: Strip Android binaries
+      - name: Strip debug symbols Android binaries
         run: |
-          ${{ matrix.strip_tool }} ${{ matrix.output_dir }}/${{ matrix.library_path }}
+          ${{ matrix.strip_tool }} --strip-debug ${{ matrix.output_dir }}/${{ matrix.library_path }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Since we now compile a static lib file, the strip command is too aggressive. It was originally intended for the .so file. This fixes the issue.