### PR TITLE
remove non-target entries leaking into DawnTargets.cmake

### DIFF
--- a/src/cmake/BundleLibraries.cmake
+++ b/src/cmake/BundleLibraries.cmake
@@ -68,9 +68,6 @@ function(bundle_libraries output_target library_type)
     foreach(dependency IN LISTS interface_link_libraries)
       if(TARGET ${dependency})
         get_dependencies(${dependency}) # Recursive call
-      elseif(NOT "${dependency}" STREQUAL "" AND NOT "${dependency}" STREQUAL "interface_link_libraries-NOTFOUND")
-        # Collect non-target link dependencies (system/shared libraries, linker flags, etc.)
-        list(APPEND all_non_target_libs ${dependency})
       endif()
     endforeach()
 


### PR DESCRIPTION
I am using find_package(Dawn REQUIRED) and got:

```
CMake Error: The link interface of target "dawn::webgpu_dawn" contains:
  dawn::partition_alloc
but the target was not found.
```

DawnTargets.cmake incorrectly includes dawn::partition_alloc
since commit 96e9e61f as part of webgpu_dawn's link interface:

```cmake
set_target_properties(dawn::webgpu_dawn PROPERTIES
  INTERFACE_LINK_LIBRARIES "...;dawn::partition_alloc;...")
```

dawn::partition_alloc is a header-only internal target that is never
installed, so any downstream find_package(Dawn) fails.