### PR TITLE
Vulkan/Qualcomm: temporary resolve textures from AlwaysResolveIntoZeroLevelAndLayer can stay alive too long and trigger OOM

### DIFF
--- a/src/dawn/native/CommandBuffer.cpp
+++ b/src/dawn/native/CommandBuffer.cpp
@@ -25,6 +25,8 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <iterator>
+
 #include "dawn/native/CommandBuffer.h"
 
 #include "dawn/native/Buffer.h"
@@ -45,6 +47,7 @@ CommandBufferBase::CommandBufferBase(CommandEncoder* encoder,
       mCommands(encoder->AcquireCommands()),
       mResourceUsages(encoder->AcquireResourceUsages()),
       mIndirectDrawMetadata(encoder->AcquireIndirectDrawMetadata()),
+      mTemporaryTexturesForEarlyDestroy(encoder->AcquireTemporaryTexturesForEarlyDestroy()),
       mEncoderLabel(encoder->GetLabel()) {
     GetObjectTrackingList()->Track(this);
 }
@@ -103,6 +106,20 @@ const CommandBufferResourceUsage& CommandBufferBase::GetResourceUsages() const {
 
 const ityp::vector<PassIndex, IndirectDrawMetadata>& CommandBufferBase::GetIndirectDrawMetadata() {
     return mIndirectDrawMetadata;
+}
+
+void CommandBufferBase::ExtractTemporaryTexturesForEarlyDestroy(
+    std::vector<Ref<TextureBase>>* temporaryTexturesForEarlyDestroy) {
+    if (mTemporaryTexturesForEarlyDestroy.empty()) {
+        return;
+    }
+
+    temporaryTexturesForEarlyDestroy->insert(temporaryTexturesForEarlyDestroy->end(),
+                                             std::make_move_iterator(
+                                                 mTemporaryTexturesForEarlyDestroy.begin()),
+                                             std::make_move_iterator(
+                                                 mTemporaryTexturesForEarlyDestroy.end()));
+    mTemporaryTexturesForEarlyDestroy.clear();
 }
 
 CommandIterator* CommandBufferBase::GetCommandIteratorForTesting() {

--- a/src/dawn/native/CommandBuffer.h
+++ b/src/dawn/native/CommandBuffer.h
@@ -68,6 +68,8 @@ class CommandBufferBase : public ApiObjectBase {
     const CommandBufferResourceUsage& GetResourceUsages() const;
 
     const ityp::vector<PassIndex, IndirectDrawMetadata>& GetIndirectDrawMetadata();
+    void ExtractTemporaryTexturesForEarlyDestroy(
+        std::vector<Ref<TextureBase>>* temporaryTexturesForEarlyDestroy);
 
     CommandIterator* GetCommandIteratorForTesting();
 
@@ -81,6 +83,7 @@ class CommandBufferBase : public ApiObjectBase {
 
     CommandBufferResourceUsage mResourceUsages;
     ityp::vector<PassIndex, IndirectDrawMetadata> mIndirectDrawMetadata;
+    std::vector<Ref<TextureBase>> mTemporaryTexturesForEarlyDestroy;
     std::string mEncoderLabel;
 };
 

--- a/src/dawn/native/CommandEncoder.cpp
+++ b/src/dawn/native/CommandEncoder.cpp
@@ -1278,8 +1278,16 @@ CommandIterator CommandEncoder::AcquireCommands() {
     return mEncodingContext.AcquireCommands();
 }
 
+std::vector<Ref<TextureBase>> CommandEncoder::AcquireTemporaryTexturesForEarlyDestroy() {
+    return std::move(mTemporaryTexturesForEarlyDestroy);
+}
+
 void CommandEncoder::TrackUsedQuerySet(QuerySetBase* querySet) {
     mUsedQuerySets.insert(querySet);
+}
+
+void CommandEncoder::TrackTemporaryTextureForEarlyDestroy(Ref<TextureBase> texture) {
+    mTemporaryTexturesForEarlyDestroy.push_back(std::move(texture));
 }
 
 ityp::vector<PassIndex, IndirectDrawMetadata> CommandEncoder::AcquireIndirectDrawMetadata() {

--- a/src/dawn/native/CommandEncoder.h
+++ b/src/dawn/native/CommandEncoder.h
@@ -62,8 +62,10 @@ class CommandEncoder final : public ApiObjectBase {
     CommandIterator AcquireCommands();
     CommandBufferResourceUsage AcquireResourceUsages();
     ityp::vector<PassIndex, IndirectDrawMetadata> AcquireIndirectDrawMetadata();
+    std::vector<Ref<TextureBase>> AcquireTemporaryTexturesForEarlyDestroy();
 
     void TrackUsedQuerySet(QuerySetBase* querySet);
+    void TrackTemporaryTextureForEarlyDestroy(Ref<TextureBase> texture);
 
     // Dawn API
     ComputePassEncoder* APIBeginComputePass(const ComputePassDescriptor* descriptor);
@@ -144,6 +146,7 @@ class CommandEncoder final : public ApiObjectBase {
     absl::flat_hash_set<BufferBase*> mTopLevelBuffers;
     absl::flat_hash_set<TextureBase*> mTopLevelTextures;
     absl::flat_hash_set<QuerySetBase*> mUsedQuerySets;
+    std::vector<Ref<TextureBase>> mTemporaryTexturesForEarlyDestroy;
 
     uint64_t mDebugGroupStackSize = 0;
 

--- a/src/dawn/native/RenderPassWorkaroundsHelper.cpp
+++ b/src/dawn/native/RenderPassWorkaroundsHelper.cpp
@@ -151,6 +151,7 @@ MaybeError RenderPassWorkaroundsHelper::Initialize(
                     DAWN_ASSERT(device->IsLockedByCurrentThreadIfNeeded());
 
                     DAWN_TRY_ASSIGN(temporaryResolveTexture, device->CreateTexture(&descriptor));
+                    encoder->TrackTemporaryTextureForEarlyDestroy(temporaryResolveTexture);
 
                     TextureViewDescriptor viewDescriptor = {};
                     DAWN_TRY_ASSIGN(

--- a/src/dawn/native/vulkan/QueueVk.cpp
+++ b/src/dawn/native/vulkan/QueueVk.cpp
@@ -103,13 +103,23 @@ MaybeError Queue::Initialize() {
 
 MaybeError Queue::SubmitImpl(uint32_t commandCount, CommandBufferBase* const* commands) {
     TRACE_EVENT_BEGIN0(GetDevice()->GetPlatform(), Recording, "CommandBufferVk::RecordCommands");
+    DAWN_ASSERT(mPendingTexturesToDestroyOnSubmit.empty());
     CommandRecordingContext* recordingContext = GetPendingRecordingContext();
     for (uint32_t i = 0; i < commandCount; ++i) {
-        DAWN_TRY(ToBackend(commands[i])->RecordCommands(recordingContext));
+        MaybeError recordResult = ToBackend(commands[i])->RecordCommands(recordingContext);
+        if (recordResult.IsError()) {
+            mPendingTexturesToDestroyOnSubmit.clear();
+            return recordResult;
+        }
+        commands[i]->ExtractTemporaryTexturesForEarlyDestroy(&mPendingTexturesToDestroyOnSubmit);
     }
     TRACE_EVENT_END0(GetDevice()->GetPlatform(), Recording, "CommandBufferVk::RecordCommands");
 
-    DAWN_TRY(SubmitPendingCommandsImpl());
+    MaybeError submitResult = SubmitPendingCommandsImpl();
+    if (submitResult.IsError()) {
+        mPendingTexturesToDestroyOnSubmit.clear();
+        return submitResult;
+    }
 
     return {};
 }
@@ -345,6 +355,13 @@ MaybeError Queue::SubmitPendingCommandsImpl() {
             mUnusedFences->push_back(fence);
         });
     TRACE_EVENT_END0(device->GetPlatform(), Recording, "vkQueueSubmit");
+
+    // Destroy temporary resolve textures while the pending serial still refers to this submit.
+    // Otherwise command-buffer teardown schedules their Vulkan memory release on the next serial.
+    for (auto& texture : mPendingTexturesToDestroyOnSubmit) {
+        texture->Destroy();
+    }
+    mPendingTexturesToDestroyOnSubmit.clear();
 
     // Enqueue the semaphores before incrementing the serial, so that they can be deleted as
     // soon as the current submission is finished.

--- a/src/dawn/native/vulkan/QueueVk.h
+++ b/src/dawn/native/vulkan/QueueVk.h
@@ -92,6 +92,7 @@ class Queue final : public QueueBase {
     MutexProtected<std::vector<CommandPoolAndBuffer>> mUnusedCommands;
     // There is always a valid recording context stored in mRecordingContext
     CommandRecordingContext mRecordingContext;
+    std::vector<Ref<TextureBase>> mPendingTexturesToDestroyOnSubmit;
 
     uint32_t mQueueFamily = 0;
     VkQueue mQueue = VK_NULL_HANDLE;


### PR DESCRIPTION
On Android Qualcomm Vulkan, Dawn enables `AlwaysResolveIntoZeroLevelAndLayer` because resolving into a non-zero array layer is buggy. In workloads that hit this path every frame, the temporary resolve textures can stay alive longer than the submit that used them, which can accumulate enough Vulkan image memory to cause OOM.

Relevant existing comments in Dawn

- `src/dawn/native/vulkan/PhysicalDeviceVk.cpp:988-996`
  - Qualcomm devices have a bug resolving into a non-zero level/layer of an array texture.
  - Qualcomm devices also have a separate bug where an empty render pass with a resolve target may not perform the resolve unless some work is injected.
- `src/dawn/native/Toggles.cpp:60-68`
  - `AlwaysResolveIntoZeroLevelAndLayer` resolves into a temporary single-layer 2D texture first, then copies into the true resolve target.
- `src/dawn/native/Toggles.cpp:705-708`
  - `VulkanAddWorkToEmptyResolvePass` exists to force empty resolve passes to execute on Qualcomm.

Problem

`RenderPassWorkaroundsHelper::Initialize()` allocates a temporary resolve texture whenever the resolve target is a non-zero mip or array layer:

- `src/dawn/native/RenderPassWorkaroundsHelper.cpp`

That texture is then used as the actual resolve target for the render pass, and copied into the intended destination in the pass end callback.

The issue is lifetime management:

- there is no explicit submit-tied early destroy path for these temporary textures
- they can remain referenced by the `CommandBufferBase` object after submission
- in WebGPU, command buffer wrapper lifetime can extend until JS GC, so these temp textures can live across many frames
- on Qualcomm Vulkan, these temp textures are often large direct allocations, so repeated per-frame creation can grow memory quickly

In my repro, this shows up in a WebXR/WebGPU workload on Quest:

- the XR color target is a 2-layer array texture
- each eye uses a 2D view into one array layer
- the right eye resolve goes to `baseArrayLayer = 1`
- that reliably triggers `AlwaysResolveIntoZeroLevelAndLayer`
- repeating this every frame eventually OOMs

This is separate from the empty-resolve-pass bug. `VulkanAddWorkToEmptyResolvePass` is needed to make the resolve happen at all on Qualcomm, but the memory growth is caused by the lifetime of the temporary resolve texture used by `AlwaysResolveIntoZeroLevelAndLayer`.

Expected behavior

Temporary resolve textures created solely for the workaround should be released as soon as the submit that uses them has been queued, independent of command buffer wrapper lifetime.

Proposed fix

Track these temporary textures from `CommandEncoder` into `CommandBufferBase`, then in Vulkan:

1. extract them during `Queue::SubmitImpl()`
2. call `Destroy()` on them immediately after `vkQueueSubmit`
3. do this before the queue serial advances, so fenced deletion is associated with the submission that actually used the image

This makes their Vulkan image/memory eligible for release on the correct serial and avoids depending on command buffer destruction / GC timing.