### PR TITLE
Fix setDepthClipMode breaking Metal API validation when running under an iOS simulator

### DIFF
--- a/src/dawn/native/metal/CommandBufferMTL.mm
+++ b/src/dawn/native/metal/CommandBufferMTL.mm
@@ -1972,9 +1972,8 @@ MaybeError CommandBuffer::EncodeRenderPass(
                 // When using and unclipped depth we need to clamp to the viewport, otherwise
                 // Metal writes the raw value to the depth buffer, which doesn't match other
                 // APIs.
-                MTLDepthClipMode clipMode =
-                    newPipeline->HasUnclippedDepth() ? MTLDepthClipModeClamp : MTLDepthClipModeClip;
-                [encoder setDepthClipMode:clipMode];
+                if (newPipeline->UsesFragDepth() || newPipeline->HasUnclippedDepth())
+                    [encoder setDepthClipMode:MTLDepthClipModeClamp];
 
                 newPipeline->Encode(encoder);
 


### PR DESCRIPTION
# Description

When running dawn on an iOS simulator, the initialization fails with the error message "Depth Clip Mode is not supported on this device". The iOS simulator apparently does not support depth clip mode. This patch avoid setting it if not strictly necessary.

Closes issue #457771794. All credits to the original author in https://issues.chromium.org/issues/457771794.

# Changes

The change is in `src/dawn/native/metal/CommandBufferMTL.mm` and simply avoids calling `[encoder setDepthClipMode:MTLDepthClipModeClamp]` if the pipeline does not call for it.