### PR TITLE
vulkan: enumerate portability-subset Vulkan implementations on macOS

### DIFF
--- a/src/dawn/native/vulkan/BackendVk.cpp
+++ b/src/dawn/native/vulkan/BackendVk.cpp
@@ -481,6 +481,16 @@ ResultOrError<VulkanGlobalKnobs> VulkanInstance::CreateVkInstance(const Instance
     createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     createInfo.pNext = nullptr;
     createInfo.flags = 0;
+    // When the loader advertises VK_KHR_portability_enumeration (canonical
+    // case: macOS host with MoltenVK as the Vulkan implementation), the
+    // ENUMERATE_PORTABILITY bit is required for non-conformant
+    // portability-subset implementations to be visible at
+    // vkEnumeratePhysicalDevices time. Without this, the application sees
+    // an empty device list even when `vulkaninfo` finds MoltenVK through
+    // the same loader.
+    if (usedKnobs.HasExt(InstanceExt::PortabilityEnumeration)) {
+        createInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+    }
     createInfo.pApplicationInfo = &appInfo;
     createInfo.enabledLayerCount = static_cast<uint32_t>(layerNames.size());
     createInfo.ppEnabledLayerNames = layerNames.data();
@@ -580,12 +590,16 @@ std::vector<Ref<PhysicalDeviceBase>> Backend::DiscoverPhysicalDevices(
     };
 
     for (ICD icd : kICDs) {
-#if DAWN_PLATFORM_IS(MACOS)
-        // On Mac, we don't expect non-Swiftshader Vulkan to be available.
-        if (icd == ICD::None) {
-            continue;
-        }
-#endif  // DAWN_PLATFORM_IS(MACOS)
+        // Historically Dawn skipped ICD::None on macOS because no non-
+        // SwiftShader Vulkan was expected. With Apple Silicon and a
+        // working MoltenVK installation in the Vulkan SDK, that assumption
+        // no longer holds — MoltenVK is loaded via the normal loader ICD
+        // path (ICD::None from Dawn's perspective). Skipping it means
+        // Dawn never enumerates the device, even though `vulkaninfo`
+        // sees it through the same loader. The companion changes to
+        // VulkanExtensions.{h,cpp} + the ENUMERATE_PORTABILITY flag in
+        // CreateVkInstance above let Dawn opt-in to the portability path
+        // when the loader advertises it.
         // We always search for fallback adapters first, so if we already found one, don't bother
         // looking for more.
         if (options->forceFallbackAdapter && !physicalDevices.empty()) {

--- a/src/dawn/native/vulkan/VulkanExtensions.cpp
+++ b/src/dawn/native/vulkan/VulkanExtensions.cpp
@@ -52,6 +52,7 @@ static constexpr std::array<InstanceExtInfo, kInstanceExtCount> sInstanceExtInfo
 
     {InstanceExt::DebugUtils, "VK_EXT_debug_utils"},
     {InstanceExt::ValidationFeatures, "VK_EXT_validation_features"},
+    {InstanceExt::PortabilityEnumeration, "VK_KHR_portability_enumeration"},
     //
 }};
 
@@ -92,6 +93,7 @@ InstanceExtSet EnsureDependencies(const InstanceExtSet& advertisedExts) {
             case InstanceExt::Surface:
             case InstanceExt::DebugUtils:
             case InstanceExt::ValidationFeatures:
+            case InstanceExt::PortabilityEnumeration:
                 hasDependencies = true;
                 break;
 

--- a/src/dawn/native/vulkan/VulkanExtensions.h
+++ b/src/dawn/native/vulkan/VulkanExtensions.h
@@ -52,6 +52,14 @@ enum class InstanceExt : uint32_t {
     DebugUtils,
     ValidationFeatures,
 
+    // VK_KHR_portability_enumeration: required for the Vulkan loader to
+    // enumerate non-conformant (portability-subset) Vulkan implementations.
+    // The canonical use case is macOS hosts running MoltenVK as the Vulkan
+    // implementation. Conformant device-side Vulkan (Adreno on Android,
+    // desktop drivers on Linux/Windows) does not require this extension —
+    // it's purely a host-loader-level opt-in.
+    PortabilityEnumeration,
+
     EnumCount,
 };
 


### PR DESCRIPTION
## Summary

Three surgical edits that let Dawn's Vulkan backend enumerate and use portability-subset Vulkan implementations (MoltenVK, KosmicKrisp, future) on macOS hosts. Without these, requesting `wgpu::BackendType::Vulkan` on macOS returns `RequestAdapterStatus::Unavailable` ("No supported adapters") even when `vulkaninfo` finds the same ICD through the same loader.

Note: I'm aware Dawn's primary code review happens on Gerrit ([dawn-review.googlesource.com](https://dawn-review.googlesource.com)). Happy to re-submit there if preferred — opening this here first as draft so I can link upstream PRs to the spike artifacts. Please let me know which workflow you'd like.

## Why

Two upstream gaps stack:

**Gap 1: `vkCreateInstance` doesn't opt in to portability enumeration.**
Per the Vulkan loader spec, non-conformant (portability-subset) Vulkan implementations are invisible to applications that don't:
- enable `VK_KHR_portability_enumeration`, AND
- set `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` on `VkInstanceCreateInfo::flags`.

Dawn does neither. Result: `vkEnumeratePhysicalDevices` returns 0 on macOS even though a portability-subset ICD is loaded.

**Gap 2: `Backend::DiscoverPhysicalDevices` skips `ICD::None` on macOS.**
```cpp
for (ICD icd : kICDs) {
#if DAWN_PLATFORM_IS(MACOS)
    if (icd == ICD::None) continue;   // "we don't expect non-SwiftShader Vulkan to be available"
#endif
```
That assumption predates Apple Silicon portability-subset Vulkan implementations (MoltenVK, KosmicKrisp). These ICDs are loaded via the loader's normal ICD path (which is `ICD::None` from Dawn's perspective), so the skip prevents Dawn from probing them — even after Gap 1 is fixed.

## Changes

- `src/dawn/native/vulkan/VulkanExtensions.h`: add `InstanceExt::PortabilityEnumeration` enumerant.
- `src/dawn/native/vulkan/VulkanExtensions.cpp`: add `{InstanceExt::PortabilityEnumeration, "VK_KHR_portability_enumeration"}` to the name table + a matching case in `EnsureDependencies` (no transitive deps).
- `src/dawn/native/vulkan/BackendVk.cpp`:
  - In `CreateVkInstance`, set `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` on `createInfo.flags` when the loader advertises the extension.
  - Remove the macOS-only `ICD::None` skip in `Backend::DiscoverPhysicalDevices`. Replace it with a comment explaining the now-fixed historical concern.

## Behavior on non-Apple platforms

- **Adreno / Android**: not a portability-subset device — the loader doesn't advertise the extension, `HasExt(...)` returns false, the new `createInfo.flags |=` is a no-op. The `ICD::None` loop already ran on Android (no `#if DAWN_PLATFORM_IS(ANDROID)` guard) so removing the macOS skip changes nothing there.
- **Linux/Windows**: same — conformant Vulkan, extension not advertised, flag-set is a no-op.

## Test plan

- [x] Build on Apple Silicon (M1, macOS 14, AppleClang 17, Vulkan SDK 1.4.341, MoltenVK 1.4.1) with `-DDAWN_ENABLE_VULKAN=ON -DTINT_BUILD_SPV_WRITER=ON`.
- [x] Same backend-agnostic WGSL triangle renders byte-identical PNG (3,885 bytes, MD5 `bfb7f207fb7e0535a829e5f0a63df60b`) on `--backend metal` and `--backend vulkan` from the same `triangle.cpp` binary.
- [x] End-to-end stereo XR render via [dawnxr](https://github.com/upf-gti/dawnxr) against Meta XR Simulator 71.0.0 — 276 frames in 5s at 1680×1760 per eye (Quest 3 native projection resolution), full OpenXR session-state lifecycle.
- [ ] (Not run by me — requires Google's CQ access) Existing Vulkan-backend tests on Linux/Windows/Android. I do not expect regressions because the new code is gated on `HasExt(PortabilityEnumeration)` which is false on conformant Vulkan implementations.

## Context

Discovered while iterating on a Quest 3 (Android NDK + Adreno Vulkan) Dawn-native + OpenXR application using the Meta XR Simulator on Mac as the inner-loop validation target. The portability_enumeration support is broadly useful for any Mac developer working on a Quest-target Vulkan code path locally without a real Vulkan headset — collapsing iteration time from minutes-with-headset-don/doff to seconds at a desktop terminal.
