### PR TITLE
fix(🐛): Vulkan: Fix double force-set of VulkanUseExtendedDynamicState

### DIFF
--- a/src/dawn/native/vulkan/PhysicalDeviceVk.cpp
+++ b/src/dawn/native/vulkan/PhysicalDeviceVk.cpp
@@ -1102,7 +1102,14 @@ void PhysicalDevice::SetupBackendDeviceToggles(dawn::platform::Platform* platfor
 
         // Disable use of ExtendedDynamicState on SwitfShader. It doesn't appear to be handling all
         // dynamic states properly, specifically some stencil ops.
-        deviceToggles->ForceSet(Toggle::VulkanUseExtendedDynamicState, false);
+        //
+        // Only force-disable when the extension is actually advertised. When it isn't, the generic
+        // availability check below already force-disables the toggle, and force-setting the same
+        // toggle twice trips the DAWN_CHECK(!mForcedToggles.Has(toggle)) in TogglesState::ForceSet.
+        if (GetDeviceInfo().HasExt(DeviceExt::ExtendedDynamicState) &&
+            GetDeviceInfo().extendedDynamicStateFeatures.extendedDynamicState == VK_TRUE) {
+            deviceToggles->ForceSet(Toggle::VulkanUseExtendedDynamicState, false);
+        }
     }
 
     if (IsIntelMesa()) {


### PR DESCRIPTION
On React Native WebGPU, we allow users to use the SwiftShader Vulkan adapter, we just throw a warning to explain that this is just very slow and a link to the documentation on how to use MoltenVK for Android simulator for instance. But honestly we would also be ok with disabling it too.

Regardless, I've noticed a regression where now it crashes: 
SetupBackendDeviceToggles force-disables VulkanUseExtendedDynamicState in two places: the SwiftShader block and the generic "extension not advertised / feature VK_FALSE" block. On SwiftShader builds that don't advertise ExtendedDynamicState, both run, so the second ForceSet trips DAWN_CHECK(!mForcedToggles.Has(toggle)) in TogglesState::ForceSet and aborts device setup (regressing Vulkan-on-SwiftShader, e.g. Android Simulator via React Native WebGPU). The SwiftShader override is only needed when the extension is advertised-but-buggy, so guard it on the extension being present; the generic path covers the not-advertised case. Exactly one ForceSet on every path.