### PR TITLE
Fix potential unsigned integer underflow in ComputeMaxIndirectValidationBatchOffsetRange

### DIFF
--- a/src/dawn/native/IndirectDrawMetadata.cpp
+++ b/src/dawn/native/IndirectDrawMetadata.cpp
@@ -40,8 +40,13 @@
 namespace dawn::native {
 
 uint64_t ComputeMaxIndirectValidationBatchOffsetRange(const CombinedLimits& limits) {
-    return limits.v1.maxStorageBufferBindingSize - limits.v1.minStorageBufferOffsetAlignment -
-           kDrawIndexedIndirectSize;
+    uint64_t requiredSubtrahend =
+        static_cast<uint64_t>(limits.v1.minStorageBufferOffsetAlignment) +
+        kDrawIndexedIndirectSize;
+    if (limits.v1.maxStorageBufferBindingSize <= requiredSubtrahend) {
+        return 0;
+    }
+    return limits.v1.maxStorageBufferBindingSize - requiredSubtrahend;
 }
 
 IndirectDrawMetadata::IndexedIndirectBufferValidationInfo::IndexedIndirectBufferValidationInfo(


### PR DESCRIPTION
### Description
This patch addresses a potential unsigned integer underflow vulnerability within the indirect drawing validation subsystem, specifically inside `ComputeMaxIndirectValidationBatchOffsetRange()` in `src/dawn/native/IndirectDrawMetadata.cpp`.

### Component
`src/dawn/native/IndirectDrawMetadata.cpp`

### Root Cause & Fix
Currently, the function performs a continuous subtraction chain using unsigned types (`uint64_t` and `uint32_t`) without evaluating whether the base constraints wrap around:
```cpp
return limits.v1.maxStorageBufferBindingSize
     - limits.v1.minStorageBufferOffsetAlignment
     - kDrawIndexedIndirectSize;
     - If a testing adapter or a specific custom environment configures a tiny maxStorageBufferBindingSize that falls below the combined value of minStorageBufferOffsetAlignment and kDrawIndexedIndirectSize, the arithmetic wraps around to a massive value close to UINT64_MAX. This inflated range breaks subsequent batch validation constraints downstream.

Changes introduced in this PR:

    Pre-compute the required combined subtrahend (minStorageBufferOffsetAlignment + kDrawIndexedIndirectSize) with explicit static type-casting to ensure arithmetic precision alignment.

    Introduce a strict logical guard: If maxStorageBufferBindingSize is less than or equal to the required subtrahend, return a fallback invariant ceiling of 0 immediately to safely block the underflow sequence.

Testing

    Verified locally that the layout calculations build correctly with standard dawn_unit_tests configurations without regression vectors.