### PR TITLE
fix(🍏):  Allow base vertex/instance draws on the iOS Simulator

### DIFF
--- a/src/dawn/native/metal/PhysicalDeviceMTL.mm
+++ b/src/dawn/native/metal/PhysicalDeviceMTL.mm
@@ -416,7 +416,12 @@ void PhysicalDevice::SetupBackendDeviceToggles(dawn::platform::Platform* platfor
         deviceToggles->Default(Toggle::MetalUseArgumentBuffers, false);
 
         bool haveBaseVertexBaseInstance = true;
-#if DAWN_PLATFORM_IS(IOS) && !DAWN_PLATFORM_IS(TVOS) && \
+        // The iOS Simulator only advertises the MTLFeatureSet_iOS_GPUFamily2 feature set, but
+        // base vertex/instance draws execute correctly there because Metal commands are serviced
+        // by the host GPU, which always supports them.
+        // NOTE: TARGET_OS_SIMULATOR can be defined but set to false for MacOS builds.
+#if DAWN_PLATFORM_IS(IOS) && !DAWN_PLATFORM_IS(TVOS) &&        \
+    (!defined(TARGET_OS_SIMULATOR) || !TARGET_OS_SIMULATOR) && \
     (!defined(__IPHONE_16_0) || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_16_0)
         haveBaseVertexBaseInstance = [*mDevice supportsFeatureSet:MTLFeatureSet_iOS_GPUFamily3_v1];
 #endif


### PR DESCRIPTION
The Simulator only advertises the GPUFamily2 feature but the Metal host has GPUFamily3. The issue/fix has been verified on the RN WebGPU test suite. We currently work around the issue by disabling the `disable_base_instance` and `disable_base_vertex` toggles if on the iOS Simulator