### PR TITLE
fix(🐛): Route surfaces configured with viewFormats through the blit path

### DIFF
--- a/src/dawn/native/vulkan/SwapChainVk.cpp
+++ b/src/dawn/native/vulkan/SwapChainVk.cpp
@@ -195,6 +195,19 @@ MaybeError SwapChain::Initialize(SwapChainBase* previousSwapChain) {
     createInfo.clipped = VK_FALSE;
     createInfo.oldSwapchain = previousVkSwapChain;
 
+    // Create the swapchain images with VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT so they can be
+    // reinterpreted to the configuration's viewFormats. VK_KHR_swapchain_mutable_format
+    // requires the full list of formats to be provided, including the image format itself.
+    VkImageFormatListCreateInfo imageFormatListInfo;
+    if (!mConfig.viewFormats.empty()) {
+        createInfo.flags |= VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR;
+        imageFormatListInfo.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO;
+        imageFormatListInfo.pNext = nullptr;
+        imageFormatListInfo.viewFormatCount = static_cast<uint32_t>(mConfig.viewFormats.size());
+        imageFormatListInfo.pViewFormats = mConfig.viewFormats.data();
+        createInfo.pNext = &imageFormatListInfo;
+    }
+
     DAWN_TRY(CheckVkSuccess(
         device->fn.CreateSwapchainKHR(device->GetVkDevice(), &createInfo, nullptr, &*mSwapChain),
         "CreateSwapChain"));
@@ -272,10 +285,13 @@ ResultOrError<SwapChain::Config> SwapChain::ChooseConfig(
     VkImageUsageFlags targetUsages =
         VulkanImageUsage(GetDevice(), GetUsage(), GetDevice()->GetValidInternalFormat(GetFormat()));
     VkImageUsageFlags supportedUsages = surfaceInfo.capabilities.supportedUsageFlags;
-    // The swapchain images are also unable to satisfy viewFormats: they are
-    // created without VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT, so they cannot be
-    // reinterpreted. The blit texture is a regular texture and can.
-    if (!IsSubset(targetUsages, supportedUsages) || !GetViewFormats().empty()) {
+    // Without VK_KHR_swapchain_mutable_format the swapchain images are created
+    // without VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT, so they cannot be reinterpreted
+    // to the configuration's viewFormats. The blit texture is a regular texture and can.
+    const bool viewFormatsRequireBlit =
+        !GetViewFormats().empty() &&
+        !ToBackend(GetDevice())->GetDeviceInfo().HasExt(DeviceExt::SwapchainMutableFormat);
+    if (!IsSubset(targetUsages, supportedUsages) || viewFormatsRequireBlit) {
         config.needsBlit = true;
     } else {
         config.usage = targetUsages;
@@ -297,6 +313,18 @@ ResultOrError<SwapChain::Config> SwapChain::ChooseConfig(
     if (!formatIsSupported) {
         return DAWN_INTERNAL_ERROR(absl::StrFormat(
             "Vulkan SwapChain must support %s with sRGB colorspace.", config.wgpuFormat));
+    }
+
+    // If the swapchain images are exposed to the user directly and need to be reinterpreted
+    // to the configuration's viewFormats, gather the full list of formats used to create the
+    // swapchain with VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR.
+    if (!config.needsBlit && !GetViewFormats().empty()) {
+        DAWN_ASSERT(
+            ToBackend(GetDevice())->GetDeviceInfo().HasExt(DeviceExt::SwapchainMutableFormat));
+        config.viewFormats.push_back(config.format);
+        for (wgpu::TextureFormat viewFormat : GetViewFormats()) {
+            config.viewFormats.push_back(VulkanImageFormat(ToBackend(GetDevice()), viewFormat));
+        }
     }
 
     // Only the identity transform with opaque alpha is supported for now.
@@ -554,6 +582,11 @@ ResultOrError<SwapChainTextureInfo> SwapChain::GetCurrentTextureInternal(bool is
     textureDesc.size.height = mConfig.extent.height;
     textureDesc.format = mConfig.wgpuFormat;
     textureDesc.usage = mConfig.wgpuUsage;
+    if (!mConfig.needsBlit) {
+        // The swapchain images were created mutable so the user-facing texture supports the
+        // configuration's viewFormats. In the blit case they stay on the blit texture instead.
+        textureDesc.viewFormats = GetViewFormats();
+    }
 
     mTexture = SwapChainTexture::Create(device, Unpack(&textureDesc), lastImage.image);
 

--- a/src/dawn/native/vulkan/SwapChainVk.cpp
+++ b/src/dawn/native/vulkan/SwapChainVk.cpp
@@ -272,7 +272,10 @@ ResultOrError<SwapChain::Config> SwapChain::ChooseConfig(
     VkImageUsageFlags targetUsages =
         VulkanImageUsage(GetDevice(), GetUsage(), GetDevice()->GetValidInternalFormat(GetFormat()));
     VkImageUsageFlags supportedUsages = surfaceInfo.capabilities.supportedUsageFlags;
-    if (!IsSubset(targetUsages, supportedUsages)) {
+    // The swapchain images are also unable to satisfy viewFormats: they are
+    // created without VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT, so they cannot be
+    // reinterpreted. The blit texture is a regular texture and can.
+    if (!IsSubset(targetUsages, supportedUsages) || !GetViewFormats().empty()) {
         config.needsBlit = true;
     } else {
         config.usage = targetUsages;

--- a/src/dawn/native/vulkan/SwapChainVk.cpp
+++ b/src/dawn/native/vulkan/SwapChainVk.cpp
@@ -195,6 +195,25 @@ MaybeError SwapChain::Initialize(SwapChainBase* previousSwapChain) {
     createInfo.clipped = VK_FALSE;
     createInfo.oldSwapchain = previousVkSwapChain;
 
+    // Create the swapchain images with VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT so they can be
+    // reinterpreted to the configuration's viewFormats. VK_KHR_swapchain_mutable_format requires
+    // the full list of formats to be provided, including the image format itself.
+    VkImageFormatListCreateInfo imageFormatListInfo;
+    std::vector<VkFormat> viewFormats;
+    if (!mConfig.wgpuViewFormats.empty()) {
+        DAWN_ASSERT(device->GetDeviceInfo().HasExt(DeviceExt::SwapchainMutableFormat));
+        createInfo.flags |= VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR;
+        viewFormats.push_back(mConfig.format);
+        for (wgpu::TextureFormat viewFormat : mConfig.wgpuViewFormats) {
+            viewFormats.push_back(VulkanImageFormat(device, viewFormat));
+        }
+        imageFormatListInfo.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO;
+        imageFormatListInfo.pNext = nullptr;
+        imageFormatListInfo.viewFormatCount = static_cast<uint32_t>(viewFormats.size());
+        imageFormatListInfo.pViewFormats = viewFormats.data();
+        createInfo.pNext = &imageFormatListInfo;
+    }
+
     DAWN_TRY(CheckVkSuccess(
         device->fn.CreateSwapchainKHR(device->GetVkDevice(), &createInfo, nullptr, &*mSwapChain),
         "CreateSwapChain"));
@@ -272,14 +291,20 @@ ResultOrError<SwapChain::Config> SwapChain::ChooseConfig(
     VkImageUsageFlags targetUsages =
         VulkanImageUsage(GetDevice(), GetUsage(), GetDevice()->GetValidInternalFormat(GetFormat()));
     VkImageUsageFlags supportedUsages = surfaceInfo.capabilities.supportedUsageFlags;
-    // The swapchain images are also unable to satisfy viewFormats: they are
-    // created without VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT, so they cannot be
-    // reinterpreted. The blit texture is a regular texture and can.
-    if (!IsSubset(targetUsages, supportedUsages) || !GetViewFormats().empty()) {
-        config.needsBlit = true;
-    } else {
+    // The swapchain images support the configuration's viewFormats only if they are created
+    // with VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT, which requires VK_KHR_swapchain_mutable_format.
+    // Otherwise the blit texture, a regular texture, is used to support them.
+    const bool viewFormatsSupported =
+        GetViewFormats().empty() ||
+        ToBackend(GetDevice())->GetDeviceInfo().HasExt(DeviceExt::SwapchainMutableFormat);
+    if (IsSubset(targetUsages, supportedUsages) && viewFormatsSupported) {
         config.usage = targetUsages;
         config.wgpuUsage = GetUsage();
+        // The swapchain will be created with VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR so the
+        // images can be reinterpreted to these formats.
+        config.wgpuViewFormats = GetViewFormats();
+    } else {
+        config.needsBlit = true;
     }
 
     // Only support BGRA8Unorm (and RGBA8Unorm on android) with SRGB color space for now.
@@ -548,12 +573,13 @@ ResultOrError<SwapChainTextureInfo> SwapChain::GetCurrentTextureInternal(bool is
     }
     lastImage.lastAcquireDoneFence = std::move(acquireFence);
 
-    // Wait on the previous fence and destroy it.
+    // Wrap the swapchain texture.
     TextureDescriptor textureDesc;
     textureDesc.size.width = mConfig.extent.width;
     textureDesc.size.height = mConfig.extent.height;
     textureDesc.format = mConfig.wgpuFormat;
     textureDesc.usage = mConfig.wgpuUsage;
+    textureDesc.viewFormats = mConfig.wgpuViewFormats;
 
     mTexture = SwapChainTexture::Create(device, Unpack(&textureDesc), lastImage.image);
 
@@ -563,8 +589,9 @@ ResultOrError<SwapChainTextureInfo> SwapChain::GetCurrentTextureInternal(bool is
         return swapChainTextureInfo;
     }
 
-    // The blit texture always perfectly matches what the user requested for the swapchain.
-    // We need to add the Vulkan TRANSFER_SRC flag for the vkCmdBlitImage call.
+    // The blit texture always perfectly matches what the user requested for the swapchain,
+    // including the viewFormats which GetSwapChainBaseTextureDescriptor() carries over. We need
+    // to add the Vulkan TRANSFER_SRC flag for the vkCmdBlitImage call.
     TextureDescriptor desc = GetSwapChainBaseTextureDescriptor(this);
     DAWN_TRY_ASSIGN(mBlitTexture, InternalTexture::Create(device, Unpack(&desc),
                                                           VK_IMAGE_USAGE_TRANSFER_SRC_BIT));

--- a/src/dawn/native/vulkan/SwapChainVk.h
+++ b/src/dawn/native/vulkan/SwapChainVk.h
@@ -66,6 +66,11 @@ class SwapChain : public SwapChainBase {
         uint32_t targetImageCount;
         VkSurfaceTransformFlagBitsKHR transform;
         VkCompositeAlphaFlagBitsKHR alphaMode;
+        // When non-empty, the swapchain is created with
+        // VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR and this list (which includes `format`)
+        // is chained as a VkImageFormatListCreateInfo so the images can be reinterpreted to
+        // the configuration's viewFormats.
+        std::vector<VkFormat> viewFormats;
 
         // Redundant information but as WebGPU enums to create the wgpu::Texture that
         // encapsulates the native swapchain texture.

--- a/src/dawn/native/vulkan/SwapChainVk.h
+++ b/src/dawn/native/vulkan/SwapChainVk.h
@@ -71,6 +71,10 @@ class SwapChain : public SwapChainBase {
         // encapsulates the native swapchain texture.
         wgpu::TextureUsage wgpuUsage;
         wgpu::TextureFormat wgpuFormat;
+        // When non-empty, the swapchain is created with
+        // VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR so its images can be reinterpreted to
+        // these formats, and the wrapped texture exposes them as its viewFormats.
+        std::vector<wgpu::TextureFormat> wgpuViewFormats;
 
         // Information about the blit workarounds we need to do (if any)
         bool needsBlit = false;

--- a/src/dawn/native/vulkan/VulkanExtensions.cpp
+++ b/src/dawn/native/vulkan/VulkanExtensions.cpp
@@ -149,6 +149,7 @@ static constexpr std::array<DeviceExtInfo, kDeviceExtCount> sDeviceExtInfos{{
     {DeviceExt::DepthClipEnable, "VK_EXT_depth_clip_enable"},
     {DeviceExt::ImageDrmFormatModifier, "VK_EXT_image_drm_format_modifier"},
     {DeviceExt::Swapchain, "VK_KHR_swapchain"},
+    {DeviceExt::SwapchainMutableFormat, "VK_KHR_swapchain_mutable_format"},
     {DeviceExt::QueueFamilyForeign, "VK_EXT_queue_family_foreign"},
     {DeviceExt::Robustness2, "VK_EXT_robustness2"},
     {DeviceExt::DisplayTiming, "VK_GOOGLE_display_timing"},
@@ -251,6 +252,12 @@ DeviceExtSet EnsureDependencies(const DeviceExtSet& advertisedExts,
 
             case DeviceExt::Swapchain:
                 hasDependencies = instanceExts[InstanceExt::Surface];
+                break;
+
+            // Also requires VK_KHR_maintenance2 which is core in Vulkan 1.1.
+            case DeviceExt::SwapchainMutableFormat:
+                hasDependencies =
+                    HasDep(DeviceExt::Swapchain) && HasDep(DeviceExt::ImageFormatList);
                 break;
 
             case DeviceExt::ExternalMemoryAndroidHardwareBuffer:

--- a/src/dawn/native/vulkan/VulkanExtensions.h
+++ b/src/dawn/native/vulkan/VulkanExtensions.h
@@ -108,6 +108,7 @@ enum class DeviceExt : uint32_t {
     DepthClipEnable,
     ImageDrmFormatModifier,
     Swapchain,
+    SwapchainMutableFormat,
     QueueFamilyForeign,
     Robustness2,
     DisplayTiming,

--- a/src/dawn/tests/end2end/SurfaceTests.cpp
+++ b/src/dawn/tests/end2end/SurfaceTests.cpp
@@ -719,6 +719,34 @@ TEST_P(SurfaceTests, Storage) {
     ASSERT_EQ(wgpu::Status::Success, surface.Present());
 }
 
+// Test acquiring a texture from a surface configured with viewFormats.
+TEST_P(SurfaceTests, ConfigureWithViewFormats) {
+    wgpu::Surface surface = CreateTestSurface();
+    wgpu::SurfaceConfiguration config = GetPreferredConfiguration(surface);
+
+    // Reinterpretation between a format and its srgb counterpart is always
+    // allowed; pick the counterpart of whatever the surface prefers.
+    wgpu::TextureFormat viewFormat;
+    switch (config.format) {
+        case wgpu::TextureFormat::BGRA8Unorm:
+            viewFormat = wgpu::TextureFormat::BGRA8UnormSrgb;
+            break;
+        case wgpu::TextureFormat::RGBA8Unorm:
+            viewFormat = wgpu::TextureFormat::RGBA8UnormSrgb;
+            break;
+        default:
+            GTEST_SKIP() << "Preferred surface format has no srgb counterpart";
+    }
+    config.viewFormatCount = 1;
+    config.viewFormats = &viewFormat;
+    surface.Configure(&config);
+
+    wgpu::SurfaceTexture surfaceTexture;
+    surface.GetCurrentTexture(&surfaceTexture);  // aborts on Vulkan before the fix
+    ClearTexture(surfaceTexture.texture, {1.0, 0.0, 0.0, 1.0});
+    surface.Present();
+}
+
 // TODO(crbug.com/465183957): Implement swap chain for WebGPUBackend.
 DAWN_INSTANTIATE_TEST(SurfaceTests,
                       D3D11Backend(),

--- a/src/dawn/tests/end2end/SurfaceTests.cpp
+++ b/src/dawn/tests/end2end/SurfaceTests.cpp
@@ -743,7 +743,22 @@ TEST_P(SurfaceTests, ConfigureWithViewFormats) {
 
     wgpu::SurfaceTexture surfaceTexture;
     surface.GetCurrentTexture(&surfaceTexture);  // aborts on Vulkan before the fix
-    ClearTexture(surfaceTexture.texture, {1.0, 0.0, 0.0, 1.0});
+
+    // Render through a view using the reinterpreted format to check the texture really
+    // supports its viewFormats.
+    wgpu::TextureViewDescriptor viewDesc;
+    viewDesc.format = viewFormat;
+    utils::ComboRenderPassDescriptor renderPassDesc(
+        {surfaceTexture.texture.CreateView(&viewDesc)});
+    renderPassDesc.cColorAttachments[0].loadOp = wgpu::LoadOp::Clear;
+    renderPassDesc.cColorAttachments[0].clearValue = {1.0, 0.0, 0.0, 1.0};
+
+    wgpu::CommandEncoder encoder = device.CreateCommandEncoder();
+    wgpu::RenderPassEncoder pass = encoder.BeginRenderPass(&renderPassDesc);
+    pass.End();
+    wgpu::CommandBuffer commands = encoder.Finish();
+    queue.Submit(1, &commands);
+
     surface.Present();
 }
 

--- a/src/dawn/tests/end2end/SurfaceTests.cpp
+++ b/src/dawn/tests/end2end/SurfaceTests.cpp
@@ -722,6 +722,8 @@ TEST_P(SurfaceTests, Storage) {
 // Test acquiring a texture from a surface configured with viewFormats.
 TEST_P(SurfaceTests, ConfigureWithViewFormats) {
     wgpu::Surface surface = CreateTestSurface();
+    wgpu::SurfaceCapabilities caps;
+    surface.GetCapabilities(adapter, &caps);
     wgpu::SurfaceConfiguration config = GetPreferredConfiguration(surface);
 
     // Reinterpretation between a format and its srgb counterpart is always
@@ -739,11 +741,37 @@ TEST_P(SurfaceTests, ConfigureWithViewFormats) {
     }
     config.viewFormatCount = 1;
     config.viewFormats = &viewFormat;
+    // When supported, also request CopySrc so the reinterpreted values can be read back.
+    if (caps.usages & wgpu::TextureUsage::CopySrc) {
+        config.usage |= wgpu::TextureUsage::CopySrc;
+    }
     surface.Configure(&config);
 
     wgpu::SurfaceTexture surfaceTexture;
     surface.GetCurrentTexture(&surfaceTexture);  // aborts on Vulkan before the fix
-    ClearTexture(surfaceTexture.texture, {1.0, 0.0, 0.0, 1.0});
+
+    // Clear through a view using the reinterpreted format to check the texture really
+    // supports its viewFormats.
+    wgpu::TextureViewDescriptor viewDesc;
+    viewDesc.format = viewFormat;
+    utils::ComboRenderPassDescriptor renderPassDesc({surfaceTexture.texture.CreateView(&viewDesc)});
+    renderPassDesc.cColorAttachments[0].loadOp = wgpu::LoadOp::Clear;
+    renderPassDesc.cColorAttachments[0].clearValue = {0.5, 0.5, 0.5, 1.0};
+
+    wgpu::CommandEncoder encoder = device.CreateCommandEncoder();
+    wgpu::RenderPassEncoder pass = encoder.BeginRenderPass(&renderPassDesc);
+    pass.End();
+    wgpu::CommandBuffer commands = encoder.Finish();
+    queue.Submit(1, &commands);
+
+    if (surfaceTexture.texture.GetUsage() & wgpu::TextureUsage::CopySrc) {
+        // The sRGB view encodes the linear 0.5 clear value to ~0.735 on store, so the raw
+        // non-sRGB pixels read back as ~187.5 instead of 128 if the reinterpretation took
+        // effect. A gray value keeps the check independent of the BGRA/RGBA channel order.
+        EXPECT_PIXEL_RGBA8_BETWEEN(utils::RGBA8(187, 187, 187, 255),
+                                   utils::RGBA8(188, 188, 188, 255), surfaceTexture.texture, 0, 0);
+    }
+
     surface.Present();
 }
 


### PR DESCRIPTION
Added check for viewFormats in swapchain image usage validation.The Vulkan swapchain creates its images without VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT and wraps them in a texture descriptor that omits the configuration's viewFormats, so the first GetCurrentTexture() fails the viewFormats consistency DAWN_CHECK and aborts. Any non-empty viewFormats now sets needsBlit, like an unsupported extent or usage: the user-facing texture becomes the intermediate blit texture, a regular texture created from the full descriptor, which supports reinterpretation.

Metal already builds the swapchain texture from the full descriptor and is unaffected. Adds a SurfaceTests end2end case; the file previously only exercised viewFormatCount = 0, which is why this went unnoticed.