### PR TITLE
fix(🐛): re-create swapchain on VK_TIMEOUT/VK_NOT_READY

### DIFF
--- a/src/dawn/native/vulkan/SwapChainVk.cpp
+++ b/src/dawn/native/vulkan/SwapChainVk.cpp
@@ -502,7 +502,14 @@ ResultOrError<SwapChainTextureInfo> SwapChain::GetCurrentTextureInternal(bool is
         case VK_SUBOPTIMAL_KHR:
             swapChainTextureInfo.status = wgpu::SurfaceGetCurrentTextureStatus::SuccessSuboptimal;
             break;
-
+        // The infinite timeout above makes VK_TIMEOUT and VK_NOT_READY
+        // spec-illegal here, but some Android drivers (Adreno, Mali) return
+        // them anyway when the compositor has stopped releasing swapchain
+        // buffers (backgrounding, screen-off, system UI transitions). A
+        // recreated swapchain gets a fresh set of buffers, so treat this like
+        // OUT_OF_DATE instead of letting it escalate to device loss.
+        case VK_TIMEOUT:
+        case VK_NOT_READY:
         case VK_ERROR_OUT_OF_DATE_KHR: {
             swapChainTextureInfo.status = wgpu::SurfaceGetCurrentTextureStatus::Outdated;
             // Prevent infinite recursive calls to GetCurrentTextureViewInternal when the

--- a/src/dawn/native/vulkan/SwapChainVk.cpp
+++ b/src/dawn/native/vulkan/SwapChainVk.cpp
@@ -502,7 +502,13 @@ ResultOrError<SwapChainTextureInfo> SwapChain::GetCurrentTextureInternal(bool is
         case VK_SUBOPTIMAL_KHR:
             swapChainTextureInfo.status = wgpu::SurfaceGetCurrentTextureStatus::SuccessSuboptimal;
             break;
-
+        // The infinite timeout above makes VK_TIMEOUT and VK_NOT_READY spec-illegal here, but
+        // some Android drivers (Adreno, Mali) return them anyway when the compositor has stopped
+        // releasing swapchain buffers (backgrounding, screen-off, system UI transitions). A
+        // recreated swapchain gets a fresh set of buffers, so treat this like OUT_OF_DATE instead
+        // of letting it escalate to device loss.
+        case VK_TIMEOUT:
+        case VK_NOT_READY:
         case VK_ERROR_OUT_OF_DATE_KHR: {
             swapChainTextureInfo.status = wgpu::SurfaceGetCurrentTextureStatus::Outdated;
             // Prevent infinite recursive calls to GetCurrentTextureViewInternal when the


### PR DESCRIPTION
[Bone Tide](https://x.com/reczko_konrad/status/2083514256423575753) which runs on top of React Native WebGPU has been released to the App and Google Play Store.

On Android some users have experienced the following error:
<img width="2400" height="1080" alt="IMG_8865" src="https://github.com/user-attachments/assets/d8743169-47b7-4f0b-9a0c-9d70397b4bf9" />

This seems to suggest that some Android drivers return a VK_TIMEOUT even though the requested timeout was infinite.