### PR TITLE
CIPD: Add riscv64 string to detect native riscv64.

### DIFF
--- a/tools/python/cipd_deps.py
+++ b/tools/python/cipd_deps.py
@@ -75,4 +75,9 @@ def get_cipd_compatible_current_arch() -> str:
     native_x86 = platform.machine().lower() in ('x86', 'x86_64', 'amd64')
     if native_x86:
         return 'amd64'
+
+    native_riscv64 = platform.machine().lower() in ('riscv64', )
+    if native_riscv64:
+        return 'riscv64'
+
     raise ValueError('Unable to determine architecture')


### PR DESCRIPTION
That's what platform.machine reports on Linux, causing failure to build on riscv64.

Unclear whether we also need an emulated_x86-style fallback like arm64 has (detecting armv8 via platform.processor() when platform.machine() reports x86). What situations run x86 Python on arm64? And if platform.machine() is unreliable in that case, why not rely solely on platform.processor() instead?