### PR TITLE
[tint] Fix tint_info crash from uninitialized input_format

### DIFF
--- a/src/tint/cmd/common/helper.h
+++ b/src/tint/cmd/common/helper.h
@@ -94,7 +94,7 @@ struct LoadProgramOptions {
     /// The file to be loaded, might be "-" for stdin
     std::string filename;
     /// The input format. Optional for files, mandatory for stdin
-    InputFormat input_format;
+    InputFormat input_format = InputFormat::kUnknown;
 #if TINT_BUILD_SPV_READER
     /// Spirv-reader options
     tint::spirv::reader::Options spirv_reader_options;


### PR DESCRIPTION
LoadProgramOptions::input_format was left uninitialized. tint_info's main.cc never sets it, so LoadProgramInfo() reads stack garbage.

If that garbage isn't kUnknown, this check is skipped:

    if (input_format == InputFormat::kUnknown) {
        input_format = InputFormatFromFilename(opts.filename);
    }

If InputFormatFromFilename() never runs, the garbage value falls through every case in the switch statement, and the program crashes at TINT_UNREACHABLE().