### PR TITLE
Generate and expose upstream-flavored WebGPU C++ headers

### DIFF
--- a/generator/dawn_json_generator.py
+++ b/generator/dawn_json_generator.py
@@ -1778,13 +1778,37 @@ class MultiGeneratorFromDawnJSON(Generator):
                            [RENDER_PARAMS_BASE, params_dawn]))
 
         if 'webgpu_headers' in targets:
+            imported_templates += [
+                "BSD_LICENSE",
+                "dawn/cpp_macros.tmpl",
+            ]
+
             params_upstream = parse_json(loaded_json,
                                          enabled_tags=['native'],
                                          disabled_tags=['dawn'])
-            imported_templates.append('BSD_LICENSE')
             renders.append(
                 FileRender('api.h', 'webgpu-headers/' + api + '.h',
                            [RENDER_PARAMS_BASE, params_upstream]))
+
+            upstream_cpp = 'include/webgpu_upstream/' + api + '/' + api
+            renders.append(
+                FileRender('api_cpp.h', upstream_cpp + '_cpp.h', [
+                    RENDER_PARAMS_BASE, params_upstream, {
+                        'c_header': api + '/' + api + '.h',
+                        'c_namespace': None,
+                    }
+                ]))
+            renders.append(
+                FileRender('api_cpp_chained_struct.h',
+                           upstream_cpp + '_cpp_chained_struct.h',
+                           [RENDER_PARAMS_BASE, params_upstream]))
+            renders.append(
+                FileRender('api_cpp_print.h', upstream_cpp + '_cpp_print.h', [
+                    RENDER_PARAMS_BASE, params_upstream, {
+                        'cpp_header': api + '/' + api + '_cpp.h',
+                        'c_namespace': None,
+                    }
+                ]))
 
         if 'emdawnwebgpu_headers' in targets:
             imported_templates += [

--- a/src/dawn/BUILD.gn
+++ b/src/dawn/BUILD.gn
@@ -109,9 +109,47 @@ dawn_json_generator("webgpu_headers_gen") {
   target = "webgpu_headers"
   inputs = [
     "${dawn_template_dir}/api.h",
+    "${dawn_template_dir}/api_cpp.h",
+    "${dawn_template_dir}/api_cpp_chained_struct.h",
+    "${dawn_template_dir}/api_cpp_print.h",
+    "${dawn_template_dir}/dawn/cpp_macros.tmpl",
     "${dawn_template_dir}/BSD_LICENSE",
   ]
-  outputs = [ "webgpu-headers/webgpu.h" ]
+  outputs = [
+    "webgpu-headers/webgpu.h",
+    "include/webgpu_upstream/webgpu/webgpu_cpp.h",
+    "include/webgpu_upstream/webgpu/webgpu_cpp_chained_struct.h",
+    "include/webgpu_upstream/webgpu/webgpu_cpp_print.h",
+  ]
+}
+
+###############################################################################
+# Upstream WebGPU C++ headers
+###############################################################################
+
+copy("webgpu_upstream_cpp_bitmasks") {
+  sources = [ "${dawn_root}/include/webgpu/webgpu_enum_class_bitmasks.h" ]
+  outputs =
+      [ "${dawn_gen_root}/include/webgpu_upstream/webgpu/{{source_file_part}}" ]
+}
+
+config("webgpu_upstream_cpp_public") {
+  include_dirs = [ "${dawn_gen_root}/include/webgpu_upstream" ]
+}
+
+source_set("webgpu_upstream_cpp_headers") {
+  all_dependent_configs = [ ":webgpu_upstream_cpp_public" ]
+  public_deps = [
+    ":webgpu_headers_gen",
+    ":webgpu_upstream_cpp_bitmasks",
+    "${dawn_root}/include/dawn:headers",
+  ]
+  sources = [
+    "${dawn_gen_root}/include/webgpu_upstream/webgpu/webgpu_cpp.h",
+    "${dawn_gen_root}/include/webgpu_upstream/webgpu/webgpu_cpp_chained_struct.h",
+    "${dawn_gen_root}/include/webgpu_upstream/webgpu/webgpu_cpp_print.h",
+    "${dawn_gen_root}/include/webgpu_upstream/webgpu/webgpu_enum_class_bitmasks.h",
+  ]
 }
 
 ###############################################################################

--- a/src/dawn/CMakeLists.txt
+++ b/src/dawn/CMakeLists.txt
@@ -239,3 +239,51 @@ DawnJSONGenerator(
 add_custom_target(webgpu_headers_gen
     DEPENDS ${WEBGPU_HEADERS_GEN_HEADERS}
 )
+
+###############################################################################
+# Upstream WebGPU C++ headers
+#   Pairs with the webgpu.h of whichever implementation is targeted
+###############################################################################
+
+set(WEBGPU_UPSTREAM_GEN_DIR
+    "${DAWN_BUILD_GEN_DIR}/include/webgpu_upstream")
+
+# Needed alongside the generated headers
+add_custom_command(
+    OUTPUT
+        "${WEBGPU_UPSTREAM_GEN_DIR}/webgpu/webgpu_enum_class_bitmasks.h"
+    DEPENDS
+        "${DAWN_INCLUDE_DIR}/webgpu/webgpu_enum_class_bitmasks.h"
+    COMMAND ${CMAKE_COMMAND} -E copy
+        "${DAWN_INCLUDE_DIR}/webgpu/webgpu_enum_class_bitmasks.h"
+        "${WEBGPU_UPSTREAM_GEN_DIR}/webgpu/webgpu_enum_class_bitmasks.h"
+)
+set(WEBGPU_UPSTREAM_CPP_HEADERS
+    "${WEBGPU_UPSTREAM_GEN_DIR}/webgpu/webgpu_cpp.h"
+    "${WEBGPU_UPSTREAM_GEN_DIR}/webgpu/webgpu_cpp_chained_struct.h"
+    "${WEBGPU_UPSTREAM_GEN_DIR}/webgpu/webgpu_cpp_print.h"
+    "${WEBGPU_UPSTREAM_GEN_DIR}/webgpu/webgpu_enum_class_bitmasks.h"
+)
+
+add_custom_target(webgpu_upstream_cpp_headers_gen ALL
+    DEPENDS "${WEBGPU_UPSTREAM_GEN_DIR}/webgpu/webgpu_enum_class_bitmasks.h"
+)
+add_dependencies(webgpu_upstream_cpp_headers_gen webgpu_headers_gen)
+
+add_library(webgpu_upstream_cpp_headers INTERFACE)
+add_library(dawn::webgpu_upstream_cpp_headers
+    ALIAS webgpu_upstream_cpp_headers)
+# BEFORE so this flavor wins over Dawn's webgpu/webgpu_cpp.h
+target_include_directories(webgpu_upstream_cpp_headers BEFORE INTERFACE
+    "$<BUILD_INTERFACE:${WEBGPU_UPSTREAM_GEN_DIR}>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/webgpu_upstream>"
+)
+
+target_link_libraries(webgpu_upstream_cpp_headers INTERFACE dawn_public_config)
+add_dependencies(webgpu_upstream_cpp_headers webgpu_upstream_cpp_headers_gen)
+
+if (DAWN_ENABLE_INSTALL)
+    install(TARGETS webgpu_upstream_cpp_headers EXPORT DawnTargets)
+    install(FILES ${WEBGPU_UPSTREAM_CPP_HEADERS}
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/webgpu_upstream/webgpu")
+endif ()


### PR DESCRIPTION
This change would allow using the `webgpu_cpp.h` bindings on top of any `webgpu.h` implementation instead of being tied to dawn's flavor. Exposed as `webgpu_upstream_cpp_headers` in CMake and GN.

Was discussed in https://github.com/webgpu-native/webgpu-headers/issues/596#issuecomment-5342110421