### PR TITLE
Metal: export GetMTLCommandQueue

### DIFF
--- a/include/dawn/native/MetalBackend.h
+++ b/include/dawn/native/MetalBackend.h
@@ -49,6 +49,11 @@ DAWN_NATIVE_EXPORT void WaitForCommandsToBeScheduled(WGPUDevice device);
 #if defined(__OBJC__)
 // Return the MTLDevice corresponding to the WGPUDevice.
 DAWN_NATIVE_EXPORT id<MTLDevice> GetMTLDevice(WGPUDevice device);
+
+// Return the MTLCommandQueue the WGPUDevice's default queue submits on, so that work submitted
+// alongside Dawn's is ordered by submission rather than by a cross-queue fence. The D3D12 backend
+// exports the same thing as GetD3D12CommandQueue.
+DAWN_NATIVE_EXPORT id<MTLCommandQueue> GetMTLCommandQueue(WGPUDevice device);
 #endif
 
 }  // namespace dawn::native::metal

--- a/src/dawn/native/metal/MetalBackend.mm
+++ b/src/dawn/native/metal/MetalBackend.mm
@@ -47,4 +47,9 @@ id<MTLDevice> GetMTLDevice(WGPUDevice device) {
     return backendDevice->GetMTLDevice();
 }
 
+id<MTLCommandQueue> GetMTLCommandQueue(WGPUDevice device) {
+    Device* backendDevice = ToBackend(FromAPI(device));
+    return ToBackend(backendDevice->GetQueue())->GetMTLCommandQueue();
+}
+
 }  // namespace dawn::native::metal

--- a/src/dawn/native/metal/QueueMTL.h
+++ b/src/dawn/native/metal/QueueMTL.h
@@ -57,6 +57,7 @@ class Queue final : public QueueBase {
     FutureID GetCommandsScheduledFuture();
 
     id<MTLSharedEvent> GetMTLSharedEvent() const;
+    id<MTLCommandQueue> GetMTLCommandQueue() const;
     ResultOrError<Ref<SharedFence>> GetOrCreateSharedFence();
 
   private:

--- a/src/dawn/native/metal/QueueMTL.mm
+++ b/src/dawn/native/metal/QueueMTL.mm
@@ -257,6 +257,10 @@ id<MTLSharedEvent> Queue::GetMTLSharedEvent() const {
     return mMtlSharedEvent.Get();
 }
 
+id<MTLCommandQueue> Queue::GetMTLCommandQueue() const {
+    return mCommandQueue.Get();
+}
+
 ResultOrError<Ref<SharedFence>> Queue::GetOrCreateSharedFence() {
     if (mSharedFence) {
         return mSharedFence;


### PR DESCRIPTION
The D3D12 backend already exports GetD3D12CommandQueue so that an app can submit interop work onto Dawn's own queue and let submission order do the ordering. The Metal backend has no equivalent, which forces interop work onto a second MTLCommandQueue synchronised with MTLSharedEvents in both directions.

Add the Metal twin, in the same shape: a Queue accessor for mCommandQueue and a backend entry point that reaches it through the device's default queue.