### PR TITLE
[dawn][common] Restore explicit operator== in ityp::array

### DIFF
--- a/src/dawn/common/ityp_array.h
+++ b/src/dawn/common/ityp_array.h
@@ -63,7 +63,9 @@ class array {
 
     // Methods that are exactly like std::array
 
-    constexpr bool operator==(const array<Index, Value, Size>& other) const = default;
+    constexpr bool operator==(const array<Index, Value, Size>& other) const {
+        return mPrivate == other.mPrivate;
+    }
 
     constexpr auto begin() { return mPrivate.begin(); }
     constexpr auto begin() const { return mPrivate.begin(); }


### PR DESCRIPTION
GCC failed because ityp::array is instantiated with ObjectStore, which has no operator==.
GCC is happy when we write the body explicitly instead of defaulting it.