### PR TITLE
Honor the surface's alphaMode in the D3D swapchain

### DIFF
--- a/src/dawn/native/BUILD.gn
+++ b/src/dawn/native/BUILD.gn
@@ -520,6 +520,9 @@ source_set("sources") {
   # WinPIX should be added as third party tools and linked statically
 
   if (dawn_enable_d3d11 || dawn_enable_d3d12) {
+    # dcomp.lib provides DCompositionCreateDevice, used by SwapChainD3D to present
+    # per-pixel-transparent HWND surfaces through a DirectComposition visual.
+    libs += [ "dcomp.lib" ]
     sources += [
       "d3d/BackendD3D.cpp",
       "d3d/BackendD3D.h",

--- a/src/dawn/native/CMakeLists.txt
+++ b/src/dawn/native/CMakeLists.txt
@@ -360,7 +360,9 @@ if (DAWN_ENABLE_D3D11 OR DAWN_ENABLE_D3D12)
         "d3d/SwapChainD3D.cpp"
         "d3d/UtilsD3D.cpp"
     )
-    list(APPEND conditional_private_platform_depends dxguid.lib)
+    # dcomp.lib provides DCompositionCreateDevice, used by SwapChainD3D to present
+    # per-pixel-transparent HWND surfaces through a DirectComposition visual.
+    list(APPEND conditional_private_platform_depends dxguid.lib dcomp.lib)
 endif()
 
 if (DAWN_ENABLE_D3D11)

--- a/src/dawn/native/d3d/SwapChainD3D.cpp
+++ b/src/dawn/native/d3d/SwapChainD3D.cpp
@@ -125,6 +125,18 @@ IWinUISwapChainPanelNative : public IUnknown {
 
 SwapChain::~SwapChain() = default;
 
+bool SwapChain::UsesComposition() const {
+    // DXGI only honours a non-opaque AlphaMode on composition swapchains, so a premultiplied
+    // request has to be routed through DirectComposition. Everything else keeps the plain
+    // CreateSwapChainForHwnd path.
+    //
+    // Note PhysicalDeviceD3D advertises Opaque and Premultiplied as the supported alpha modes,
+    // so Unpremultiplied never reaches here; DComp has no straight-alpha mode to map it to
+    // anyway.
+    return GetSurface()->GetType() == Surface::Type::WindowsHWND &&
+           GetAlphaMode() == wgpu::CompositeAlphaMode::Premultiplied;
+}
+
 // Initializes the swapchain on the surface. Note that `previousSwapChain` may or may not be
 // nullptr. If it is not nullptr it means that it is the swapchain previously in use on the
 // surface and that we have a chance to reuse it's underlying IDXGISwapChain and "buffers".
@@ -140,6 +152,14 @@ MaybeError SwapChain::Initialize(SwapChainBase* previousSwapChain) {
     mConfig.format = d3d::DXGITextureFormat(GetDevice(), GetFormat());
     mConfig.swapChainFlags = PresentModeToSwapChainFlags(GetPresentMode());
     mConfig.usage = ToDXGIUsage(GetDevice(), GetFormat(), GetUsage());
+
+    if (UsesComposition()) {
+        // A composition swapchain is never the fullscreen target of a window, and DXGI rejects
+        // creation outright if ALLOW_MODE_SWITCH is set. Mask it out of mConfig rather than at
+        // the creation site so the ResizeBuffers path below stays consistent with what the
+        // swapchain was actually created with.
+        mConfig.swapChainFlags &= ~DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+    }
 
     // There is no previous swapchain so we can create one directly and don't have anything else
     // to do.
@@ -164,10 +184,13 @@ MaybeError SwapChain::Initialize(SwapChainBase* previousSwapChain) {
 
     // The previous swapchain is on the same device so we want to reuse it but it is still not
     // always possible. Because DXGI requires that a new swapchain be created if the
-    // DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING flag is changed.
+    // DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING flag is changed, or if the alpha mode changed: a
+    // swapchain's AlphaMode is fixed at creation, and a composition swapchain and an HWND
+    // swapchain are not interchangeable.
     bool canReuseSwapChain =
         ((mConfig.swapChainFlags ^ previousD3DSwapChain->mConfig.swapChainFlags) &
-         DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING) == 0;
+         DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING) == 0 &&
+        UsesComposition() == previousD3DSwapChain->UsesComposition();
 
     // We can't reuse the previous swapchain, so we destroy it and wait for all of its reference
     // to be forgotten (otherwise DXGI complains that there are outstanding references).
@@ -179,6 +202,13 @@ MaybeError SwapChain::Initialize(SwapChainBase* previousSwapChain) {
     // After all this we know we can reuse the swapchain, see if it is possible to also reuse
     // the buffers.
     mDXGISwapChain = std::move(previousD3DSwapChain->mDXGISwapChain);
+
+    // The visual tree belongs to the swapchain we just adopted, so it has to come with it.
+    // Leaving it on the previous object would destroy the target when that object dies, and
+    // the window would go blank while Present kept returning S_OK.
+    mDCompDevice = std::move(previousD3DSwapChain->mDCompDevice);
+    mDCompTarget = std::move(previousD3DSwapChain->mDCompTarget);
+    mDCompVisual = std::move(previousD3DSwapChain->mDCompVisual);
 
     bool canReuseBuffers = GetWidth() == previousSwapChain->GetWidth() &&
                            GetHeight() == previousSwapChain->GetHeight() &&
@@ -222,7 +252,12 @@ MaybeError SwapChain::InitializeSwapChainFromScratch() {
     swapChainDesc.BufferCount = mConfig.bufferCount;
     swapChainDesc.Scaling = DXGI_SCALING_STRETCH;
     swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    swapChainDesc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
+    // Honour the WebGPU surface descriptor's alphaMode. Previously this hardcoded IGNORE, which
+    // silently dropped per-pixel transparency requests even though PhysicalDeviceD3D advertises
+    // Premultiplied as supported. DXGI only accepts a non-opaque mode on composition
+    // swapchains, so this pairs with the CreateSwapChainForComposition branch below.
+    swapChainDesc.AlphaMode =
+        UsesComposition() ? DXGI_ALPHA_MODE_PREMULTIPLIED : DXGI_ALPHA_MODE_IGNORE;
     swapChainDesc.Flags = mConfig.swapChainFlags;
 
     ComPtr<IDXGIFactory2> factory2 = nullptr;
@@ -232,16 +267,32 @@ MaybeError SwapChain::InitializeSwapChainFromScratch() {
     ComPtr<IDXGISwapChain1> swapChain1;
     switch (GetSurface()->GetType()) {
         case Surface::Type::WindowsHWND: {
+            HWND hwnd = static_cast<HWND>(GetSurface()->GetHWND());
+
+            if (UsesComposition()) {
+                // Transparent path. The swapchain is created unparented and then bound to the
+                // window through a DirectComposition visual. For the window to actually show
+                // through, it must have been created WS_EX_NOREDIRECTIONBITMAP — otherwise the
+                // redirection bitmap sits behind the visual and stays opaque.
+                DAWN_TRY(CheckHRESULT(
+                    factory2->CreateSwapChainForComposition(GetD3DDeviceForCreatingSwapChain(),
+                                                            &swapChainDesc, nullptr, &swapChain1),
+                    "Creating the composition IDXGISwapChain1"));
+
+                DAWN_TRY(InitializeDComp(hwnd, swapChain1.Get()));
+
+                // No MakeWindowAssociation here: a composition swapchain isn't associated with
+                // the window, and DXGI's alt+enter handling doesn't apply to it.
+                break;
+            }
+
             DAWN_TRY(CheckHRESULT(
-                factory2->CreateSwapChainForHwnd(GetD3DDeviceForCreatingSwapChain(),
-                                                 static_cast<HWND>(GetSurface()->GetHWND()),
+                factory2->CreateSwapChainForHwnd(GetD3DDeviceForCreatingSwapChain(), hwnd,
                                                  &swapChainDesc, nullptr, nullptr, &swapChain1),
                 "Creating the IDXGISwapChain1"));
 
-            DAWN_TRY(
-                CheckHRESULT(factory2->MakeWindowAssociation(
-                                 static_cast<HWND>(GetSurface()->GetHWND()), DXGI_MWA_NO_ALT_ENTER),
-                             "Disabling DXGI's alt+enter fullscreen handling"));
+            DAWN_TRY(CheckHRESULT(factory2->MakeWindowAssociation(hwnd, DXGI_MWA_NO_ALT_ENTER),
+                                  "Disabling DXGI's alt+enter fullscreen handling"));
             break;
         }
         case Surface::Type::WindowsCoreWindow: {
@@ -289,6 +340,29 @@ MaybeError SwapChain::InitializeSwapChainFromScratch() {
     return CollectSwapChainBuffers();
 }
 
+MaybeError SwapChain::InitializeDComp(HWND hwnd, IDXGISwapChain1* swapChain) {
+    // Passing nullptr for the DXGI device lets DComp pick one. We can't hand it ours: the
+    // backend-supplied IUnknown here is an ID3D12CommandQueue on D3D12 and an ID3D11Device on
+    // D3D11, and only the latter can produce an IDXGIDevice.
+    DAWN_TRY(CheckHRESULT(DCompositionCreateDevice(nullptr, IID_PPV_ARGS(&mDCompDevice)),
+                          "DCompositionCreateDevice"));
+
+    // topmost=TRUE so the visual composites above the (absent) redirection surface.
+    DAWN_TRY(CheckHRESULT(mDCompDevice->CreateTargetForHwnd(hwnd, TRUE, &mDCompTarget),
+                          "IDCompositionDevice::CreateTargetForHwnd"));
+    DAWN_TRY(CheckHRESULT(mDCompDevice->CreateVisual(&mDCompVisual),
+                          "IDCompositionDevice::CreateVisual"));
+    DAWN_TRY(CheckHRESULT(mDCompVisual->SetContent(swapChain), "IDCompositionVisual::SetContent"));
+    DAWN_TRY(
+        CheckHRESULT(mDCompTarget->SetRoot(mDCompVisual.Get()), "IDCompositionTarget::SetRoot"));
+
+    // Nothing in the visual tree takes effect until Commit. This is a one-time cost: later
+    // frames are published by IDXGISwapChain::Present alone.
+    DAWN_TRY(CheckHRESULT(mDCompDevice->Commit(), "IDCompositionDevice::Commit"));
+
+    return {};
+}
+
 MaybeError SwapChain::PresentDXGISwapChain() {
     // Do the actual present. DXGI_STATUS_OCCLUDED is a valid return value that's just a
     // message to the application that it could stop rendering.
@@ -307,6 +381,22 @@ MaybeError SwapChain::PresentDXGISwapChain() {
 }
 
 void SwapChain::ReleaseDXGISwapChain() {
+    // Unbind the visual tree before dropping our own reference. The visual holds a reference to
+    // the swapchain, so callers that need every reference gone — DetachAndWaitForDeallocation,
+    // and the DXGI operations it exists to satisfy — would otherwise still be blocked by it.
+    if (mDCompVisual != nullptr) {
+        mDCompVisual->SetContent(nullptr);
+    }
+    if (mDCompTarget != nullptr) {
+        mDCompTarget->SetRoot(nullptr);
+    }
+    if (mDCompDevice != nullptr) {
+        mDCompDevice->Commit();
+    }
+    mDCompVisual = nullptr;
+    mDCompTarget = nullptr;
+    mDCompDevice = nullptr;
+
     mDXGISwapChain = nullptr;
 }
 

--- a/src/dawn/native/d3d/SwapChainD3D.h
+++ b/src/dawn/native/d3d/SwapChainD3D.h
@@ -34,6 +34,11 @@
 #include "src/dawn/native/SwapChain.h"
 #include "src/dawn/native/d3d/d3d_platform.h"
 
+// DirectComposition, for per-pixel-transparent HWND surfaces: DXGI only allows a non-opaque
+// AlphaMode on composition swapchains, never on the ones created by CreateSwapChainForHwnd.
+// Must come after d3d_platform.h, which brings in windows.h.
+#include <dcomp.h>
+
 namespace dawn::native::d3d {
 
 class Device;
@@ -73,12 +78,28 @@ class SwapChain : public SwapChainBase {
     };
     const Config& GetConfig() const;
 
+    // True when the surface asked for a per-pixel-transparent presentation and we therefore
+    // have to go through DirectComposition instead of CreateSwapChainForHwnd.
+    bool UsesComposition() const;
+
   private:
     // Does the swapchain initialization steps assuming there is nothing we can reuse.
     MaybeError InitializeSwapChainFromScratch();
 
+    // Builds the DirectComposition device / target / visual tree for `hwnd` and points it at
+    // `swapChain`. Only called on the composition path.
+    MaybeError InitializeDComp(HWND hwnd, IDXGISwapChain1* swapChain);
+
     Config mConfig;
     ComPtr<IDXGISwapChain3> mDXGISwapChain;
+
+    // DirectComposition objects backing a transparent HWND swapchain; null on the opaque path.
+    // These must outlive mDXGISwapChain, and must be moved across when a swapchain is recycled
+    // onto a new SwapChain object — otherwise the visual tree is destroyed with the old object
+    // and the window goes blank while still presenting successfully.
+    ComPtr<IDCompositionDevice> mDCompDevice;
+    ComPtr<IDCompositionTarget> mDCompTarget;
+    ComPtr<IDCompositionVisual> mDCompVisual;
 };
 
 }  // namespace dawn::native::d3d


### PR DESCRIPTION
`SwapChainD3D` hardcoded `DXGI_ALPHA_MODE_IGNORE` even though `PhysicalDeviceD3D` advertises `Premultiplied` as a supported alpha mode, so a surface configured for per-pixel transparency was validated and then composited as opaque.

DXGI rejects a non-opaque alpha mode on `CreateSwapChainForHwnd`, so a premultiplied HWND surface is instead created with `CreateSwapChainForComposition` and bound to the window through a DirectComposition visual whose device, target and visual hang off the swapchain and are moved across when a swapchain is recycled - leaving them behind would destroy the target while `Present` kept succeeding, and the window would go blank. `DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH` is masked out for composition swapchains, which DXGI refuses outright, and `MakeWindowAssociation` is skipped since a composition swapchain is not associated with a window. Recycling an existing swapchain now also requires the alpha mode to be unchanged: `AlphaMode` is fixed at creation, so without that check a runtime `configure()` with a different alpha mode silently adopted the old swapchain and dropped the request. `dcomp.lib` is added to both the CMake and GN builds.

For the transparency to be visible the application's window must have been created with `WS_EX_NOREDIRECTIONBITMAP`; otherwise the window's redirection surface sits behind the DirectComposition visual and stays opaque.

Split out of #69 at review request so the Windows side can be looked at separately; the Vulkan half of that change is unaffected by this one. The branch is based on current `main`, and the two PRs touch disjoint files. `ManualSurfaceTest.cpp` is deliberately absent here: the note explaining the GLFW limitation below belongs on top of the `T` key added in #69, so it should follow once that lands rather than duplicate it.

Verified on Windows 11 + NVIDIA with a Node addon embedding Dawn, driving three.js `WebGPURenderer` over a `WS_EX_NOREDIRECTIONBITMAP` window on D3D12. This cannot be demonstrated through `ManualSurfaceTest`: GLFW implements `GLFW_TRANSPARENT_FRAMEBUFFER` with `DwmEnableBlurBehindWindow`, so the window keeps a redirection surface, and `WS_EX_NOREDIRECTIONBITMAP` has no effect when applied after `CreateWindowEx`.

Known follow-ups carried over from the Gerrit comments on the combined change, not yet addressed here: the code-history comment, `break` -> `if {} else {}`, whether `UsesComposition`'s HWND check is redundant with `PhysicalDevice::GetSurfaceCapabilities` (and whether that capability computation should move here so the logic is local), and caching the DComp device on `DeviceD3D` through per-backend virtual overrides so the right `IUnknown` is passed. `dcomp.lib` availability for UWP has not been checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
